### PR TITLE
SCRUM-25: Add unit tests for SecretService

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -88,15 +88,19 @@
             "json",
             "ts"
         ],
-        "rootDir": "src",
+        "rootDir": ".",
         "testRegex": ".*\\.spec\\.ts$",
+        "roots": [
+            "<rootDir>/src",
+            "<rootDir>/tests"
+        ],
         "transform": {
             "^.+\\.(t|j)s$": "ts-jest"
         },
         "collectCoverageFrom": [
-            "**/*.(t|j)s"
+            "src/**/*.(t|j)s"
         ],
-        "coverageDirectory": "../coverage",
+        "coverageDirectory": "./coverage",
         "testEnvironment": "node"
     }
 }

--- a/api/tests/application/secrets/secrets.service.spec.ts
+++ b/api/tests/application/secrets/secrets.service.spec.ts
@@ -1,0 +1,135 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SecretService } from '../../../src/application/secrets/secrets.service';
+import { ISecretStorage, SECRET_STORAGE } from '../../../src/domain/secrets/secret-storage.interface';
+import { SecretKey } from '../../../src/domain/enums/secret-key.enum';
+import { SecretDto } from '../../../src/application/secrets/dto/secret.dto';
+
+describe('SecretService', () => {
+    let service: SecretService;
+    let mockSecretStorage: jest.Mocked<ISecretStorage>;
+
+    beforeEach(async () => {
+        mockSecretStorage = {
+            getSingle: jest.fn(),
+            getMultiple: jest.fn(),
+            set: jest.fn(),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                SecretService,
+                {
+                    provide: SECRET_STORAGE,
+                    useValue: mockSecretStorage,
+                },
+            ],
+        }).compile();
+
+        service = module.get<SecretService>(SecretService);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should retrieve a secret using getSecret and correctly delegate to scoped secret service', async () => {
+        const tenantId = 'tenant-123';
+        const key = SecretKey.OPEN_AI;
+        const expectedValue = 'sk-test-openai-key';
+        const expectedSecretName = 'tenant--tenant-123--OpenAI';
+
+        mockSecretStorage.getSingle.mockResolvedValue(expectedValue);
+
+        const result = await service.getSecret(tenantId, key);
+
+        expect(mockSecretStorage.getSingle).toHaveBeenCalledWith(expectedSecretName);
+        expect(mockSecretStorage.getSingle).toHaveBeenCalledTimes(1);
+        expect(result).toEqual({ key, value: expectedValue });
+    });
+
+    it('should list all secrets using getAllSecrets and correctly delegate to scoped secret service', async () => {
+        const tenantId = 'tenant-789';
+        const expectedSecretNames = [
+            'tenant--tenant-789--Stripe',
+            'tenant--tenant-789--OpenAI',
+        ];
+        const mockSecretsRecord: Record<string, string | null> = {
+            'tenant--tenant-789--Stripe': 'sk-test-stripe-key',
+            'tenant--tenant-789--OpenAI': 'sk-test-openai-key',
+        };
+
+        mockSecretStorage.getMultiple.mockResolvedValue(mockSecretsRecord);
+
+        const result = await service.getAllSecrets(tenantId);
+
+        expect(mockSecretStorage.getMultiple).toHaveBeenCalledWith(expectedSecretNames);
+        expect(mockSecretStorage.getMultiple).toHaveBeenCalledTimes(1);
+        expect(result).toEqual([
+            { key: SecretKey.STRIPE, value: 'sk-test-stripe-key' },
+            { key: SecretKey.OPEN_AI, value: 'sk-test-openai-key' },
+        ]);
+    });
+
+    it('should set a secret using setSecret and correctly delegate to scoped secret service', async () => {
+        const tenantId = 'tenant-set';
+        const secretDto: SecretDto = {
+            key: SecretKey.STRIPE,
+            value: 'sk-live-stripe-key',
+        };
+        const expectedSecretName = 'tenant--tenant-set--Stripe';
+
+        mockSecretStorage.set.mockResolvedValue(undefined);
+
+        await service.setSecret(tenantId, secretDto);
+
+        expect(mockSecretStorage.set).toHaveBeenCalledWith(
+            expectedSecretName,
+            secretDto.value
+        );
+        expect(mockSecretStorage.set).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle error scenarios by rethrowing errors from scoped secret service unchanged', async () => {
+        const tenantId = 'tenant-error';
+        const key = SecretKey.OPEN_AI;
+        const storageError = new Error('Storage service failure');
+        const invalidTenantError = new Error('Invalid tenant ID');
+        const missingKeysError = new Error('Failed to retrieve secrets');
+
+        mockSecretStorage.getSingle.mockRejectedValueOnce(storageError);
+        mockSecretStorage.getSingle.mockRejectedValueOnce(invalidTenantError);
+        mockSecretStorage.getMultiple.mockRejectedValueOnce(missingKeysError);
+
+        await expect(service.getSecret(tenantId, key)).rejects.toThrow(storageError);
+        await expect(service.getSecret('', SecretKey.STRIPE)).rejects.toThrow(invalidTenantError);
+        await expect(service.getAllSecrets('tenant-missing')).rejects.toThrow(missingKeysError);
+
+        expect(mockSecretStorage.getSingle).toHaveBeenCalledTimes(2);
+        expect(mockSecretStorage.getMultiple).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle empty results correctly for both getSecret returning null and getAllSecrets returning empty array', async () => {
+        const tenantId = 'tenant-empty';
+        const key = SecretKey.STRIPE;
+        const expectedSecretName = 'tenant--tenant-empty--Stripe';
+        const expectedSecretNames = [
+            'tenant--tenant-empty--Stripe',
+            'tenant--tenant-empty--OpenAI',
+        ];
+
+        mockSecretStorage.getSingle.mockResolvedValue(null);
+        mockSecretStorage.getMultiple.mockResolvedValue({});
+
+        const singleResult = await service.getSecret(tenantId, key);
+        const allResults = await service.getAllSecrets(tenantId);
+
+        expect(mockSecretStorage.getSingle).toHaveBeenCalledWith(expectedSecretName);
+        expect(singleResult).toEqual({ key, value: null });
+        
+        expect(mockSecretStorage.getMultiple).toHaveBeenCalledWith(expectedSecretNames);
+        expect(allResults).toEqual([
+            { key: SecretKey.STRIPE, value: null },
+            { key: SecretKey.OPEN_AI, value: null },
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary
- Created 5 comprehensive unit tests for SecretService to improve test coverage
- Tests validate core functionality including secret retrieval, listing, setting, error handling, and empty results
- All tests confirm correct delegation to the scoped secret service (IScopedSecretService)

## Changes
- Added `api/tests/application/secrets/secrets.service.spec.ts` with 5 independent unit tests
- Updated Jest configuration in `package.json` to include the tests directory
- Tests use real SecretKey enum values (OPEN_AI and STRIPE) as specified
- Error scenarios properly rethrow errors unchanged from the storage service
- Empty results cover both null from getSecret and empty array from getAllSecrets

## Test Coverage
The 5 unit tests cover:
1. **Secret retrieval**: Validates getSecret method correctly delegates to scoped service
2. **Listing all secrets**: Validates getAllSecrets method correctly delegates to scoped service
3. **Setting a secret**: Validates setSecret method correctly delegates to scoped service
4. **Error handling**: Tests multiple error scenarios (storage failures, invalid tenant IDs, missing keys)
5. **Empty results**: Tests both null values from getSecret and empty arrays from getAllSecrets

## Test Results
All tests pass successfully:
```
Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
```

## Acceptance Criteria Met
✅ 5 independent tests are created for SecretService
✅ Tests confirm correct delegation of calls to the scoped secret service
✅ Both success and failure scenarios are covered
✅ Tests run successfully as part of the existing test suite

🤖 Generated with [Claude Code](https://claude.ai/code)