### PR TITLE
SCRUM-30: Implement cookie consent banner for Client app

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
 import { SignedIn, SignedOut } from '@clerk/clerk-react';
 import AppRoutes from './routes/AppRoutes';
 import Login from './modules/login/Login';
+import { CookieConsentBanner } from './modules/cookies/components/CookieConsentBanner';
 
 function App() {
   return (
@@ -11,6 +12,7 @@ function App() {
       <SignedIn>
         <AppRoutes />
       </SignedIn>
+      <CookieConsentBanner />
     </>
   );
 }

--- a/client/src/modules/cookies/components/CookieConfigureModal.tsx
+++ b/client/src/modules/cookies/components/CookieConfigureModal.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  FormGroup,
+  FormControlLabel,
+  Switch,
+  Typography,
+  Box,
+  Divider,
+} from '@mui/material';
+import { COOKIE_CATEGORIES } from '../types/consent';
+import { useConsentStore } from '../stores/consentStore';
+
+export const CookieConfigureModal: React.FC = () => {
+  const {
+    isConfigureOpen,
+    tempPreferences,
+    closeConfigure,
+    updateTempPreference,
+    savePreferences,
+  } = useConsentStore();
+
+  if (!tempPreferences) return null;
+
+  return (
+    <Dialog
+      open={isConfigureOpen}
+      onClose={closeConfigure}
+      maxWidth="sm"
+      fullWidth
+      aria-labelledby="cookie-preferences-title"
+    >
+      <DialogTitle id="cookie-preferences-title">
+        Cookie Preferences
+      </DialogTitle>
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" paragraph>
+          We use cookies to enhance your browsing experience and analyze our traffic.
+          Please choose which types of cookies you want to allow.
+        </Typography>
+
+        <FormGroup>
+          {COOKIE_CATEGORIES.map((category) => (
+            <Box key={category.id} sx={{ mb: 2 }}>
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={tempPreferences[category.id as keyof typeof tempPreferences]}
+                    onChange={(e) => updateTempPreference(category.id, e.target.checked)}
+                    disabled={category.required}
+                    color="primary"
+                  />
+                }
+                label={
+                  <Box>
+                    <Typography variant="subtitle2">
+                      {category.name}
+                      {category.required && (
+                        <Typography
+                          component="span"
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ ml: 1 }}
+                        >
+                          (Always enabled)
+                        </Typography>
+                      )}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {category.description}
+                    </Typography>
+                  </Box>
+                }
+              />
+              {category.id !== 'functional' && <Divider sx={{ mt: 1 }} />}
+            </Box>
+          ))}
+        </FormGroup>
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button
+          onClick={closeConfigure}
+          color="inherit"
+          variant="outlined"
+        >
+          Cancel
+        </Button>
+        <Button
+          onClick={savePreferences}
+          variant="contained"
+          color="primary"
+        >
+          Save Preferences
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/client/src/modules/cookies/components/CookieConsentBanner.tsx
+++ b/client/src/modules/cookies/components/CookieConsentBanner.tsx
@@ -1,0 +1,148 @@
+import React, { useEffect } from 'react';
+import {
+  Box,
+  Paper,
+  Typography,
+  Button,
+  Stack,
+  Container,
+  useTheme,
+  useMediaQuery,
+  Slide,
+} from '@mui/material';
+import CookieIcon from '@mui/icons-material/Cookie';
+import { useConsentStore } from '../stores/consentStore';
+import { CookieConfigureModal } from './CookieConfigureModal';
+
+export const CookieConsentBanner: React.FC = () => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const {
+    isVisible,
+    acceptAll,
+    declineAll,
+    openConfigure,
+    initialize,
+  } = useConsentStore();
+
+  useEffect(() => {
+    initialize();
+  }, [initialize]);
+
+  return (
+    <>
+      <noscript>
+        <Box
+          sx={{
+            position: 'fixed',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            bgcolor: 'error.main',
+            color: 'error.contrastText',
+            p: 2,
+            textAlign: 'center',
+            zIndex: theme.zIndex.modal + 1,
+          }}
+        >
+          <Typography variant="body2">
+            JavaScript is disabled. Cookie consent cannot be captured without JavaScript enabled.
+          </Typography>
+        </Box>
+      </noscript>
+
+      <Slide direction="up" in={isVisible} mountOnEnter unmountOnExit>
+        <Paper
+          elevation={8}
+          sx={{
+            position: 'fixed',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            zIndex: theme.zIndex.modal,
+            borderRadius: 0,
+            borderTop: `4px solid ${theme.palette.primary.main}`,
+          }}
+        >
+          <Container maxWidth="lg">
+            <Box
+              sx={{
+                py: 3,
+                px: { xs: 2, sm: 3 },
+              }}
+            >
+              <Stack
+                direction={{ xs: 'column', md: 'row' }}
+                spacing={3}
+                alignItems={{ xs: 'flex-start', md: 'center' }}
+              >
+                <Box sx={{ flex: 1 }}>
+                  <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
+                    <CookieIcon color="primary" />
+                    <Typography variant="h6" component="h2">
+                      Cookie Consent
+                    </Typography>
+                  </Stack>
+
+                  <Typography variant="body2" color="text.secondary">
+                    We use cookies to enhance your experience on our platform.
+                    These cookies help us understand how you use our services,
+                    provide personalized content, and improve our offerings.
+                    By clicking "Accept All", you consent to our use of all cookies.
+                    You can also configure your preferences or decline non-essential cookies.
+                  </Typography>
+                </Box>
+
+                <Stack
+                  direction={{ xs: 'column', sm: 'row' }}
+                  spacing={2}
+                  sx={{
+                    width: { xs: '100%', md: 'auto' },
+                    minWidth: { md: '400px' },
+                  }}
+                >
+                  <Button
+                    variant="outlined"
+                    color="inherit"
+                    onClick={declineAll}
+                    fullWidth={isMobile}
+                    sx={{
+                      borderColor: 'divider',
+                      '&:hover': {
+                        borderColor: 'text.primary',
+                        bgcolor: 'action.hover',
+                      },
+                    }}
+                  >
+                    Decline
+                  </Button>
+
+                  <Button
+                    variant="outlined"
+                    color="primary"
+                    onClick={openConfigure}
+                    fullWidth={isMobile}
+                  >
+                    Configure
+                  </Button>
+
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={acceptAll}
+                    fullWidth={isMobile}
+                  >
+                    Accept All
+                  </Button>
+                </Stack>
+              </Stack>
+            </Box>
+          </Container>
+        </Paper>
+      </Slide>
+
+      <CookieConfigureModal />
+    </>
+  );
+};

--- a/client/src/modules/cookies/services/consentStorage.ts
+++ b/client/src/modules/cookies/services/consentStorage.ts
@@ -1,0 +1,63 @@
+import { CookieConsent, CONSENT_STORAGE_KEY } from '../types/consent';
+
+export const consentStorage = {
+  getConsent(): CookieConsent | null {
+    try {
+      const stored = localStorage.getItem(CONSENT_STORAGE_KEY);
+      if (!stored) return null;
+      return JSON.parse(stored) as CookieConsent;
+    } catch (error) {
+      console.error('Failed to retrieve cookie consent:', error);
+      return null;
+    }
+  },
+
+  setConsent(consent: CookieConsent): void {
+    try {
+      localStorage.setItem(CONSENT_STORAGE_KEY, JSON.stringify(consent));
+    } catch (error) {
+      console.error('Failed to save cookie consent:', error);
+    }
+  },
+
+  hasConsent(): boolean {
+    return this.getConsent() !== null;
+  },
+
+  acceptAll(): void {
+    const consent: CookieConsent = {
+      timestamp: Date.now(),
+      categories: {
+        essential: true,
+        analytics: true,
+        marketing: true,
+        functional: true,
+      },
+    };
+    this.setConsent(consent);
+  },
+
+  declineAll(): void {
+    const consent: CookieConsent = {
+      timestamp: Date.now(),
+      categories: {
+        essential: true,
+        analytics: false,
+        marketing: false,
+        functional: false,
+      },
+    };
+    this.setConsent(consent);
+  },
+
+  saveCustomPreferences(categories: CookieConsent['categories']): void {
+    const consent: CookieConsent = {
+      timestamp: Date.now(),
+      categories: {
+        ...categories,
+        essential: true,
+      },
+    };
+    this.setConsent(consent);
+  },
+};

--- a/client/src/modules/cookies/stores/consentStore.ts
+++ b/client/src/modules/cookies/stores/consentStore.ts
@@ -1,0 +1,106 @@
+import { create } from 'zustand';
+import { CookieConsent } from '../types/consent';
+import { consentStorage } from '../services/consentStorage';
+
+interface ConsentStore {
+  isVisible: boolean;
+  isConfigureOpen: boolean;
+  consent: CookieConsent | null;
+  tempPreferences: CookieConsent['categories'] | null;
+
+  showBanner: () => void;
+  hideBanner: () => void;
+  openConfigure: () => void;
+  closeConfigure: () => void;
+
+  acceptAll: () => void;
+  declineAll: () => void;
+  updateTempPreference: (category: string, value: boolean) => void;
+  savePreferences: () => void;
+
+  initialize: () => void;
+}
+
+export const useConsentStore = create<ConsentStore>((set, get) => ({
+  isVisible: false,
+  isConfigureOpen: false,
+  consent: null,
+  tempPreferences: null,
+
+  showBanner: () => set({ isVisible: true }),
+  hideBanner: () => set({ isVisible: false }),
+
+  openConfigure: () => {
+    const currentConsent = get().consent;
+    const defaultPreferences = currentConsent?.categories || {
+      essential: true,
+      analytics: false,
+      marketing: false,
+      functional: false,
+    };
+    set({
+      isConfigureOpen: true,
+      tempPreferences: { ...defaultPreferences },
+    });
+  },
+
+  closeConfigure: () => set({
+    isConfigureOpen: false,
+    tempPreferences: null,
+  }),
+
+  acceptAll: () => {
+    consentStorage.acceptAll();
+    const consent = consentStorage.getConsent();
+    set({
+      consent,
+      isVisible: false,
+      isConfigureOpen: false,
+    });
+  },
+
+  declineAll: () => {
+    consentStorage.declineAll();
+    const consent = consentStorage.getConsent();
+    set({
+      consent,
+      isVisible: false,
+      isConfigureOpen: false,
+    });
+  },
+
+  updateTempPreference: (category: string, value: boolean) => {
+    const tempPreferences = get().tempPreferences;
+    if (tempPreferences && category !== 'essential') {
+      set({
+        tempPreferences: {
+          ...tempPreferences,
+          [category]: value,
+        },
+      });
+    }
+  },
+
+  savePreferences: () => {
+    const tempPreferences = get().tempPreferences;
+    if (tempPreferences) {
+      consentStorage.saveCustomPreferences(tempPreferences);
+      const consent = consentStorage.getConsent();
+      set({
+        consent,
+        isVisible: false,
+        isConfigureOpen: false,
+        tempPreferences: null,
+      });
+    }
+  },
+
+  initialize: () => {
+    const consent = consentStorage.getConsent();
+    const shouldShowBanner = !consentStorage.hasConsent();
+    set({
+      consent,
+      isVisible: shouldShowBanner,
+    });
+  },
+}));

--- a/client/src/modules/cookies/types/consent.ts
+++ b/client/src/modules/cookies/types/consent.ts
@@ -1,0 +1,45 @@
+export interface CookieCategory {
+  id: string;
+  name: string;
+  description: string;
+  required: boolean;
+}
+
+export interface CookieConsent {
+  timestamp: number;
+  categories: {
+    essential: boolean;
+    analytics: boolean;
+    marketing: boolean;
+    functional: boolean;
+  };
+}
+
+export const COOKIE_CATEGORIES: CookieCategory[] = [
+  {
+    id: 'essential',
+    name: 'Essential/Necessary',
+    description: 'Required for the website to function properly. Cannot be disabled.',
+    required: true,
+  },
+  {
+    id: 'analytics',
+    name: 'Analytics/Performance',
+    description: 'Help us understand how visitors interact with our website.',
+    required: false,
+  },
+  {
+    id: 'marketing',
+    name: 'Marketing/Advertising',
+    description: 'Used to deliver relevant advertisements and track campaign effectiveness.',
+    required: false,
+  },
+  {
+    id: 'functional',
+    name: 'Functional/Preferences',
+    description: 'Enable enhanced functionality and personalization.',
+    required: false,
+  },
+];
+
+export const CONSENT_STORAGE_KEY = 'cookie-consent';


### PR DESCRIPTION
## Summary
- Implemented a cookie consent banner that appears at the bottom of the Client app on first visit
- Added three user actions: Accept All, Configure, and Decline
- Created preferences modal with toggleable cookie categories (Essential, Analytics, Marketing, Functional)
- Persists consent choice in localStorage with no expiration
- Includes no-JavaScript fallback message

## Implementation Details
- Banner positioned at fixed bottom using MUI components
- Essential/Necessary cookies are always enabled and non-toggleable
- Consent stored client-side only (no backend integration)
- Responsive design for desktop and mobile devices
- Banner won't reappear once user makes a consent choice

## Test Plan
- [ ] Verify banner appears on first visit to the Client app
- [ ] Test Accept All button - should accept all cookies and hide banner
- [ ] Test Decline button - should decline non-essential cookies and hide banner
- [ ] Test Configure button - should open preferences modal
- [ ] Verify Essential cookies cannot be disabled in preferences
- [ ] Test saving custom preferences in Configure modal
- [ ] Verify consent persists after page refresh
- [ ] Check responsive design on mobile devices
- [ ] Disable JavaScript and verify fallback message appears
- [ ] Clear localStorage and verify banner reappears

🤖 Generated with [Claude Code](https://claude.ai/code)