### PR TITLE
SCRUM-60: add color switcher

### DIFF
--- a/client/src/common/components/MainLayout.tsx
+++ b/client/src/common/components/MainLayout.tsx
@@ -23,6 +23,7 @@ import CustomUserButton from './CustomUserButton';
 import useUserRoles from '../hooks/useUserRoles';
 import { ROLES } from '../constants/roles';
 import InvoiceFileUpload from '../../modules/invoices/components/InvoiceFileUpload';
+import ThemeSwitcher from './ThemeSwitcher';
 
 const drawerWidth = 240;
 
@@ -150,6 +151,10 @@ const MainLayout: React.FC = () => {
                   {item.label}
                 </Button>
               ))}
+            </Box>
+
+            <Box sx={{ mr: 2 }}>
+              <ThemeSwitcher />
             </Box>
 
             <Box sx={{ ml: { xs: 1, md: 2 } }}>

--- a/client/src/common/components/ThemeSwitcher.tsx
+++ b/client/src/common/components/ThemeSwitcher.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Box, Switch, Typography, useTheme as useMuiTheme } from '@mui/material';
+import { useTheme } from '../contexts/ThemeContext';
+
+const ThemeSwitcher: React.FC = () => {
+  const { themeName, toggleTheme } = useTheme();
+  const muiTheme = useMuiTheme();
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+      }}
+    >
+      <Typography
+        variant="body2"
+        sx={{
+          color: themeName === 'neonDarkGreen' ? muiTheme.palette.primary.main : 'inherit',
+          fontWeight: themeName === 'neonDarkGreen' ? 600 : 400,
+        }}
+      >
+        Green
+      </Typography>
+      <Switch
+        checked={themeName === 'neonPinkyDark'}
+        onChange={toggleTheme}
+        sx={{
+          '& .MuiSwitch-switchBase.Mui-checked': {
+            color: '#ec4899',
+          },
+          '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
+            backgroundColor: '#ec4899',
+          },
+        }}
+      />
+      <Typography
+        variant="body2"
+        sx={{
+          color: themeName === 'neonPinkyDark' ? muiTheme.palette.primary.main : 'inherit',
+          fontWeight: themeName === 'neonPinkyDark' ? 600 : 400,
+        }}
+      >
+        Pink
+      </Typography>
+    </Box>
+  );
+};
+
+export default ThemeSwitcher;

--- a/client/src/common/contexts/ThemeContext.tsx
+++ b/client/src/common/contexts/ThemeContext.tsx
@@ -1,0 +1,69 @@
+import React, { createContext, useContext, useState, useEffect, ReactNode, useMemo } from 'react';
+import { ThemeProvider as MuiThemeProvider, CssBaseline } from '@mui/material';
+import { neonDarkGreenTheme } from '../themes/neonDarkGreen';
+import { neonPinkyDarkTheme } from '../themes/neonPinkyDark';
+
+export type ThemeName = 'neonDarkGreen' | 'neonPinkyDark';
+
+interface ThemeContextType {
+  themeName: ThemeName;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+const THEME_STORAGE_KEY = 'selectedTheme';
+
+const themes = {
+  neonDarkGreen: neonDarkGreenTheme,
+  neonPinkyDark: neonPinkyDarkTheme,
+};
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
+  const [themeName, setThemeName] = useState<ThemeName>(() => {
+    const savedTheme = localStorage.getItem(THEME_STORAGE_KEY) as ThemeName | null;
+    return savedTheme && savedTheme in themes ? savedTheme : 'neonDarkGreen';
+  });
+
+  useEffect(() => {
+    localStorage.setItem(THEME_STORAGE_KEY, themeName);
+  }, [themeName]);
+
+  const toggleTheme = () => {
+    setThemeName((prevTheme) =>
+      prevTheme === 'neonDarkGreen' ? 'neonPinkyDark' : 'neonDarkGreen',
+    );
+  };
+
+  const contextValue = useMemo(
+    () => ({
+      themeName,
+      toggleTheme,
+    }),
+    [themeName],
+  );
+
+  const theme = themes[themeName];
+
+  return (
+    <ThemeContext.Provider value={contextValue}>
+      <MuiThemeProvider theme={theme}>
+        <CssBaseline />
+        {children}
+      </MuiThemeProvider>
+    </ThemeContext.Provider>
+  );
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/client/src/common/themes/neonDarkGreen.ts
+++ b/client/src/common/themes/neonDarkGreen.ts
@@ -1,0 +1,182 @@
+import { createTheme } from '@mui/material';
+
+export const neonDarkGreenTheme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: {
+      main: '#1fb8aa',
+      light: '#3fc9bc',
+      dark: '#0d9488',
+      contrastText: '#000000',
+    },
+    secondary: {
+      main: '#06b6d4',
+      light: '#22d3f1',
+      dark: '#0e7490',
+      contrastText: '#000000',
+    },
+    background: {
+      default: '#0F172A', // Slate-900
+      paper: '#1E293B', // Slate-800
+    },
+    text: {
+      primary: '#FFFFFF',
+      secondary: '#94A3B8', // Slate-400
+    },
+    error: {
+      main: '#EF4444', // Red-500
+    },
+    warning: {
+      main: '#F59E0B', // Amber-500
+    },
+    info: {
+      main: '#3B82F6', // Blue-500
+    },
+    success: {
+      main: '#10B981', // Emerald-500
+    },
+    divider: '#334155', // Slate-700
+  },
+  typography: {
+    fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
+    h1: {
+      fontWeight: 700,
+    },
+    h2: {
+      fontWeight: 700,
+    },
+    h3: {
+      fontWeight: 600,
+    },
+    h4: {
+      fontWeight: 600,
+    },
+    h5: {
+      fontWeight: 600,
+    },
+    h6: {
+      fontWeight: 600,
+    },
+    button: {
+      fontWeight: 600,
+      textTransform: 'none',
+    },
+  },
+  shape: {
+    borderRadius: 8,
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          boxShadow: 'none',
+          padding: '8px 16px',
+          '&:hover': {
+            boxShadow: 'none',
+          },
+        },
+        contained: {
+          background: 'linear-gradient(to right, #1fb8aa, #0d9488)',
+          '&:hover': {
+            background: 'linear-gradient(to right, #0d9488, #0f766e)',
+          },
+        },
+        outlined: {
+          borderColor: '#1fb8aa',
+          color: '#1fb8aa',
+          '&:hover': {
+            borderColor: '#0d9488',
+            color: '#0d9488',
+            backgroundColor: 'rgba(13, 148, 136, 0.04)',
+          },
+        },
+      },
+    },
+    MuiSelect: {
+      styleOverrides: {
+        root: {
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#1fb8aa',
+          },
+          '&:hover .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#1fb8aa',
+          },
+        },
+      },
+    },
+    MuiMenuItem: {
+      styleOverrides: {
+        root: {
+          '&.Mui-selected': {
+            backgroundColor: 'rgba(31, 184, 170, 0.1)',
+          },
+          '&.Mui-selected:hover': {
+            backgroundColor: 'rgba(31, 184, 170, 0.2)',
+          },
+          '&:hover': {
+            backgroundColor: 'rgba(31, 184, 170, 0.05)',
+          },
+        },
+      },
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: 12,
+          boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
+          border: '1px solid #334155',
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+        },
+      },
+    },
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
+          backgroundImage: 'none',
+        },
+      },
+    },
+    MuiTableHead: {
+      styleOverrides: {
+        root: {
+          '& .MuiTableCell-root': {
+            fontWeight: 600,
+            color: '#FFFFFF',
+          },
+        },
+      },
+    },
+    MuiTextField: {
+      styleOverrides: {
+        root: {
+          '& .MuiOutlinedInput-root': {
+            '& fieldset': {
+              borderColor: '#334155',
+            },
+            '&:hover fieldset': {
+              borderColor: '#1fb8aa',
+            },
+            '&.Mui-focused fieldset': {
+              borderColor: '#1fb8aa',
+            },
+          },
+        },
+      },
+    },
+    MuiChip: {
+      styleOverrides: {
+        root: {
+          fontWeight: 500,
+        },
+      },
+    },
+  },
+});

--- a/client/src/common/themes/neonPinkyDark.ts
+++ b/client/src/common/themes/neonPinkyDark.ts
@@ -1,0 +1,182 @@
+import { createTheme } from '@mui/material';
+
+export const neonPinkyDarkTheme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: {
+      main: '#ec4899',
+      light: '#f472b6',
+      dark: '#db2777',
+      contrastText: '#000000',
+    },
+    secondary: {
+      main: '#a855f7',
+      light: '#c084fc',
+      dark: '#9333ea',
+      contrastText: '#000000',
+    },
+    background: {
+      default: '#0F172A', // Slate-900
+      paper: '#1E293B', // Slate-800
+    },
+    text: {
+      primary: '#FFFFFF',
+      secondary: '#94A3B8', // Slate-400
+    },
+    error: {
+      main: '#EF4444', // Red-500
+    },
+    warning: {
+      main: '#F59E0B', // Amber-500
+    },
+    info: {
+      main: '#3B82F6', // Blue-500
+    },
+    success: {
+      main: '#10B981', // Emerald-500
+    },
+    divider: '#334155', // Slate-700
+  },
+  typography: {
+    fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
+    h1: {
+      fontWeight: 700,
+    },
+    h2: {
+      fontWeight: 700,
+    },
+    h3: {
+      fontWeight: 600,
+    },
+    h4: {
+      fontWeight: 600,
+    },
+    h5: {
+      fontWeight: 600,
+    },
+    h6: {
+      fontWeight: 600,
+    },
+    button: {
+      fontWeight: 600,
+      textTransform: 'none',
+    },
+  },
+  shape: {
+    borderRadius: 8,
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          boxShadow: 'none',
+          padding: '8px 16px',
+          '&:hover': {
+            boxShadow: 'none',
+          },
+        },
+        contained: {
+          background: 'linear-gradient(to right, #ec4899, #db2777)',
+          '&:hover': {
+            background: 'linear-gradient(to right, #db2777, #be185d)',
+          },
+        },
+        outlined: {
+          borderColor: '#ec4899',
+          color: '#ec4899',
+          '&:hover': {
+            borderColor: '#db2777',
+            color: '#db2777',
+            backgroundColor: 'rgba(219, 39, 119, 0.04)',
+          },
+        },
+      },
+    },
+    MuiSelect: {
+      styleOverrides: {
+        root: {
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#ec4899',
+          },
+          '&:hover .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#ec4899',
+          },
+        },
+      },
+    },
+    MuiMenuItem: {
+      styleOverrides: {
+        root: {
+          '&.Mui-selected': {
+            backgroundColor: 'rgba(236, 72, 153, 0.1)',
+          },
+          '&.Mui-selected:hover': {
+            backgroundColor: 'rgba(236, 72, 153, 0.2)',
+          },
+          '&:hover': {
+            backgroundColor: 'rgba(236, 72, 153, 0.05)',
+          },
+        },
+      },
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: 12,
+          boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
+          border: '1px solid #334155',
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+        },
+      },
+    },
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
+          backgroundImage: 'none',
+        },
+      },
+    },
+    MuiTableHead: {
+      styleOverrides: {
+        root: {
+          '& .MuiTableCell-root': {
+            fontWeight: 600,
+            color: '#FFFFFF',
+          },
+        },
+      },
+    },
+    MuiTextField: {
+      styleOverrides: {
+        root: {
+          '& .MuiOutlinedInput-root': {
+            '& fieldset': {
+              borderColor: '#334155',
+            },
+            '&:hover fieldset': {
+              borderColor: '#ec4899',
+            },
+            '&.Mui-focused fieldset': {
+              borderColor: '#ec4899',
+            },
+          },
+        },
+      },
+    },
+    MuiChip: {
+      styleOverrides: {
+        root: {
+          fontWeight: 500,
+        },
+      },
+    },
+  },
+});

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -5,9 +5,9 @@ import { createRoot } from 'react-dom/client';
 import './styles/global.css';
 import App from './App.tsx';
 import { ClerkProvider } from '@clerk/clerk-react';
-import { ThemeProvider, createTheme, CssBaseline } from '@mui/material';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import clerkInstance from './common/services/clerkInstance.ts';
+import { ThemeProvider } from './common/contexts/ThemeContext';
 
 const PUBLISHABLE_KEY = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
 
@@ -45,193 +45,10 @@ const queryClient = new QueryClient({
   },
 });
 
-// Custom theme with invoice analytics design system
-const theme = createTheme({
-  palette: {
-    mode: 'dark',
-    primary: {
-      main: '#1fb8aa',
-      light: '#3fc9bc',
-      dark: '#0d9488',
-      contrastText: '#000000',
-    },
-    secondary: {
-      main: '#06b6d4',
-      light: '#22d3f1',
-      dark: '#0e7490',
-      contrastText: '#000000',
-    },
-    background: {
-      default: '#0F172A', // Slate-900
-      paper: '#1E293B', // Slate-800
-    },
-    text: {
-      primary: '#FFFFFF',
-      secondary: '#94A3B8', // Slate-400
-    },
-    error: {
-      main: '#EF4444', // Red-500
-    },
-    warning: {
-      main: '#F59E0B', // Amber-500
-    },
-    info: {
-      main: '#3B82F6', // Blue-500
-    },
-    success: {
-      main: '#10B981', // Emerald-500
-    },
-    divider: '#334155', // Slate-700
-  },
-  typography: {
-    fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
-    h1: {
-      fontWeight: 700,
-    },
-    h2: {
-      fontWeight: 700,
-    },
-    h3: {
-      fontWeight: 600,
-    },
-    h4: {
-      fontWeight: 600,
-    },
-    h5: {
-      fontWeight: 600,
-    },
-    h6: {
-      fontWeight: 600,
-    },
-    button: {
-      fontWeight: 600,
-      textTransform: 'none',
-    },
-  },
-  shape: {
-    borderRadius: 8,
-  },
-  components: {
-    MuiButton: {
-      styleOverrides: {
-        root: {
-          borderRadius: 8,
-          boxShadow: 'none',
-          padding: '8px 16px',
-          '&:hover': {
-            boxShadow: 'none',
-          },
-        },
-        contained: {
-          background: 'linear-gradient(to right, #1fb8aa, #0d9488)',
-          '&:hover': {
-            background: 'linear-gradient(to right, #0d9488, #0f766e)',
-          },
-        },
-        outlined: {
-          borderColor: '#1fb8aa',
-          color: '#1fb8aa',
-          '&:hover': {
-            borderColor: '#0d9488',
-            color: '#0d9488',
-            backgroundColor: 'rgba(13, 148, 136, 0.04)',
-          },
-        },
-      },
-    },
-    MuiSelect: {
-      styleOverrides: {
-        root: {
-          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-            borderColor: '#1fb8aa',
-          },
-          '&:hover .MuiOutlinedInput-notchedOutline': {
-            borderColor: '#1fb8aa',
-          },
-        },
-      },
-    },
-    MuiMenuItem: {
-      styleOverrides: {
-        root: {
-          '&.Mui-selected': {
-            backgroundColor: 'rgba(31, 184, 170, 0.1)',
-          },
-          '&.Mui-selected:hover': {
-            backgroundColor: 'rgba(31, 184, 170, 0.2)',
-          },
-          '&:hover': {
-            backgroundColor: 'rgba(31, 184, 170, 0.05)',
-          },
-        },
-      },
-    },
-    MuiCard: {
-      styleOverrides: {
-        root: {
-          borderRadius: 12,
-          boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
-          border: '1px solid #334155',
-        },
-      },
-    },
-    MuiPaper: {
-      styleOverrides: {
-        root: {
-          backgroundImage: 'none',
-        },
-      },
-    },
-    MuiAppBar: {
-      styleOverrides: {
-        root: {
-          boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
-          backgroundImage: 'none',
-        },
-      },
-    },
-    MuiTableHead: {
-      styleOverrides: {
-        root: {
-          '& .MuiTableCell-root': {
-            fontWeight: 600,
-            color: '#FFFFFF',
-          },
-        },
-      },
-    },
-    MuiTextField: {
-      styleOverrides: {
-        root: {
-          '& .MuiOutlinedInput-root': {
-            '& fieldset': {
-              borderColor: '#334155',
-            },
-            '&:hover fieldset': {
-              borderColor: '#1fb8aa',
-            },
-            '&.Mui-focused fieldset': {
-              borderColor: '#1fb8aa',
-            },
-          },
-        },
-      },
-    },
-    MuiChip: {
-      styleOverrides: {
-        root: {
-          fontWeight: 500,
-        },
-      },
-    },
-  },
-});
-
 // eslint-disable-next-line react-refresh/only-export-components
 const RootComponent: React.FC = () => {
   return (
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
+    <ThemeProvider>
       <SnackbarProvider>
         <QueryClientProvider client={queryClient}>
           <ClerkProvider publishableKey={PUBLISHABLE_KEY} afterSignOutUrl="/">


### PR DESCRIPTION
## Summary
- Added theme switcher toggle to switch between Neon Dark Green and Neon Pinky Dark themes
- Implemented theme persistence using localStorage
- Added toggle switch component in the main layout header

## Implementation Details

### Theme Configuration
- Created two theme configurations: `neonDarkGreen` (existing) and `neonPinkyDark` (new)
- Both themes maintain the same dark mode background and typography settings
- Primary colors: Green (#1fb8aa) vs Pink (#ec4899)

### Theme Context
- Implemented `ThemeContext` provider for centralized theme management
- Theme preference is saved to localStorage and persists across sessions
- Toggle function switches between the two predefined themes

### UI Component
- Added toggle switch in the main layout header
- Toggle displays "Green" and "Pink" labels
- Active theme label is highlighted with the theme's primary color

### User Requirements Met
- ✅ Theme switcher for Client app (Material UI)
- ✅ Toggle between Neon Dark Green and Neon Pinky Dark
- ✅ localStorage persistence
- ✅ Toggle switch UI component
- ✅ No animations/transitions
- ✅ Predefined themes only

## Testing
- Theme switching works correctly
- Theme preference persists on page reload
- No TypeScript or ESLint errors
- Build completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)