### PR TITLE
SCRUM-73: Add theme switcher that toggles between light and dark themes

### DIFF
--- a/client/src/common/components/CustomUserButton.tsx
+++ b/client/src/common/components/CustomUserButton.tsx
@@ -11,11 +11,14 @@ import {
   ListItemButton,
   Divider,
   Tooltip,
-  useTheme,
 } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
 import LogoutIcon from '@mui/icons-material/Logout';
+import LightModeIcon from '@mui/icons-material/LightMode';
+import DarkModeIcon from '@mui/icons-material/DarkMode';
 import { useClerk, useUser } from '@clerk/clerk-react';
+import { useTheme } from '../../themes/ThemeContext';
+import { useTheme as useMuiTheme } from '@mui/material';
 
 type CustomUserButtonProps = {
   afterSignOutUrl: string;
@@ -26,7 +29,8 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
   const buttonRef = useRef<HTMLDivElement>(null);
   const { signOut } = useClerk();
   const { user } = useUser();
-  const theme = useTheme();
+  const muiTheme = useMuiTheme();
+  const { mode, toggleTheme } = useTheme();
 
   const handleClick = (): void => {
     setAnchorEl(buttonRef.current);
@@ -47,6 +51,10 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
     handleClose();
   };
 
+  const handleToggleTheme = (): void => {
+    toggleTheme();
+  };
+
   const open = Boolean(anchorEl);
 
   return (
@@ -60,11 +68,11 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
           cursor: 'pointer',
           borderRadius: '50%',
           padding: '2px',
-          transition: theme.transitions.create(['background-color', 'box-shadow'], {
-            duration: theme.transitions.duration.shortest,
+          transition: muiTheme.transitions.create(['background-color', 'box-shadow'], {
+            duration: muiTheme.transitions.duration.shortest,
           }),
           '&:hover': {
-            backgroundColor: theme.palette.action.hover,
+            backgroundColor: muiTheme.palette.action.hover,
           },
         }}>
         <Avatar
@@ -73,7 +81,7 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
           sx={{
             width: 36,
             height: 36,
-            border: `2px solid ${theme.palette.primary.main}`,
+            border: `2px solid ${muiTheme.palette.primary.main}`,
           }}
         />
       </Box>
@@ -97,7 +105,7 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
             pt: 2,
             pb: 1,
             border: '1px solid',
-            borderColor: theme.palette.divider,
+            borderColor: muiTheme.palette.divider,
             boxShadow: '0 4px 20px rgba(0, 0, 0, 0.15)',
             backgroundImage: 'none',
           },
@@ -116,7 +124,7 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
               width: 40,
               height: 40,
               mr: 1.5,
-              border: `2px solid ${theme.palette.primary.main}`,
+              border: `2px solid ${muiTheme.palette.primary.main}`,
             }}
           />
           <Box>
@@ -124,7 +132,7 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
               <Typography
                 variant="body1"
                 sx={{
-                  color: theme.palette.text.primary,
+                  color: muiTheme.palette.text.primary,
                   maxWidth: 220,
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
@@ -147,13 +155,29 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
               sx={{
                 px: 2,
                 '&:hover': {
-                  backgroundColor: theme.palette.action.hover,
+                  backgroundColor: muiTheme.palette.action.hover,
                 },
               }}>
-              <ListItemIcon sx={{ minWidth: 36, color: theme.palette.primary.main }}>
+              <ListItemIcon sx={{ minWidth: 36, color: muiTheme.palette.primary.main }}>
                 <SettingsIcon fontSize="small" />
               </ListItemIcon>
               <ListItemText primary="Manage account" />
+            </ListItemButton>
+          </ListItem>
+
+          <ListItem disablePadding>
+            <ListItemButton
+              onClick={handleToggleTheme}
+              sx={{
+                px: 2,
+                '&:hover': {
+                  backgroundColor: muiTheme.palette.action.hover,
+                },
+              }}>
+              <ListItemIcon sx={{ minWidth: 36, color: muiTheme.palette.primary.main }}>
+                {mode === 'light' ? <DarkModeIcon fontSize="small" /> : <LightModeIcon fontSize="small" />}
+              </ListItemIcon>
+              <ListItemText primary={mode === 'light' ? 'Dark mode' : 'Light mode'} />
             </ListItemButton>
           </ListItem>
 
@@ -163,10 +187,10 @@ const CustomUserButton: React.FC<CustomUserButtonProps> = ({ afterSignOutUrl }) 
               sx={{
                 px: 2,
                 '&:hover': {
-                  backgroundColor: theme.palette.action.hover,
+                  backgroundColor: muiTheme.palette.action.hover,
                 },
               }}>
-              <ListItemIcon sx={{ minWidth: 36, color: theme.palette.primary.main }}>
+              <ListItemIcon sx={{ minWidth: 36, color: muiTheme.palette.primary.main }}>
                 <LogoutIcon fontSize="small" />
               </ListItemIcon>
               <ListItemText primary="Sign out" />

--- a/client/src/modules/home/components/HomePage.tsx
+++ b/client/src/modules/home/components/HomePage.tsx
@@ -6,7 +6,6 @@ import {
   CardContent,
   CardActionArea,
   Container,
-  Grid,
   Typography,
   Paper,
   Stack,
@@ -14,6 +13,7 @@ import {
   useTheme,
   alpha,
 } from '@mui/material';
+import Grid from '@mui/material/Grid';
 import {
   Group as UsersIcon,
   Business as TenantsIcon,
@@ -135,7 +135,7 @@ const HomePage: React.FC = () => {
             sx={{ mb: 6 }}
           >
             {filteredQuickActions.map((action) => (
-              <Grid item xs={12} sm={6} md={4} lg={3} key={action.path}>
+              <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }} key={action.path}>
                 <Card
                   elevation={0}
                   sx={{

--- a/client/src/modules/login/Login.tsx
+++ b/client/src/modules/login/Login.tsx
@@ -11,7 +11,6 @@ import {
   Stack,
   CircularProgress,
   Alert,
-  Theme,
 } from '@mui/material';
 import { useSignIn } from '@clerk/clerk-react';
 import { useState, FormEvent, ChangeEvent } from 'react';

--- a/client/src/themes/ThemeContext.tsx
+++ b/client/src/themes/ThemeContext.tsx
@@ -1,12 +1,47 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, createContext, useContext, useState, useEffect } from 'react';
 import { ThemeProvider as MuiThemeProvider } from '@mui/material';
-import { theme } from './index';
+import { lightTheme, darkTheme } from './index';
 
-// Simple theme provider with single theme
+type ThemeMode = 'light' | 'dark';
+
+interface ThemeContextType {
+  mode: ThemeMode;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};
+
+const THEME_STORAGE_KEY = 'theme-mode';
+
 export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [mode, setMode] = useState<ThemeMode>(() => {
+    const savedMode = localStorage.getItem(THEME_STORAGE_KEY);
+    return (savedMode as ThemeMode) || 'light';
+  });
+
+  useEffect(() => {
+    localStorage.setItem(THEME_STORAGE_KEY, mode);
+  }, [mode]);
+
+  const toggleTheme = () => {
+    setMode(prevMode => prevMode === 'light' ? 'dark' : 'light');
+  };
+
+  const theme = mode === 'light' ? lightTheme : darkTheme;
+
   return (
-    <MuiThemeProvider theme={theme}>
-      {children}
-    </MuiThemeProvider>
+    <ThemeContext.Provider value={{ mode, toggleTheme }}>
+      <MuiThemeProvider theme={theme}>
+        {children}
+      </MuiThemeProvider>
+    </ThemeContext.Provider>
   );
 };

--- a/client/src/themes/darkTheme.ts
+++ b/client/src/themes/darkTheme.ts
@@ -1,0 +1,191 @@
+import { createTheme } from '@mui/material';
+
+// Material UI default dark theme (dark gray #121212)
+export const darkTheme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: {
+      main: '#90CAF9',
+      light: '#B3E5FC',
+      dark: '#42A5F5',
+      contrastText: '#000000',
+    },
+    secondary: {
+      main: '#9CA3AF',
+      light: '#D1D5DB',
+      dark: '#6B7280',
+      contrastText: '#000000',
+    },
+    background: {
+      default: '#121212',
+      paper: '#1E1E1E',
+    },
+    text: {
+      primary: '#FFFFFF',
+      secondary: '#B3B3B3',
+    },
+    error: {
+      main: '#F87171',
+    },
+    warning: {
+      main: '#FBBF24',
+    },
+    info: {
+      main: '#60A5FA',
+    },
+    success: {
+      main: '#34D399',
+    },
+    divider: 'rgba(255, 255, 255, 0.12)',
+  },
+  typography: {
+    fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
+    h1: {
+      fontWeight: 700,
+    },
+    h2: {
+      fontWeight: 700,
+    },
+    h3: {
+      fontWeight: 600,
+    },
+    h4: {
+      fontWeight: 600,
+    },
+    h5: {
+      fontWeight: 600,
+    },
+    h6: {
+      fontWeight: 600,
+    },
+    button: {
+      fontWeight: 600,
+      textTransform: 'none',
+    },
+  },
+  shape: {
+    borderRadius: 8,
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          boxShadow: '0 1px 2px rgba(0, 0, 0, 0.25)',
+          padding: '8px 16px',
+          transition: 'all 0.2s ease',
+          '&:hover': {
+            boxShadow: '0 4px 6px rgba(0, 0, 0, 0.3)',
+            transform: 'translateY(-1px)',
+          },
+        },
+        contained: {
+          backgroundColor: '#90CAF9',
+          color: '#000000',
+          '&:hover': {
+            backgroundColor: '#42A5F5',
+          },
+        },
+        outlined: {
+          borderColor: 'rgba(255, 255, 255, 0.23)',
+          color: '#90CAF9',
+          '&:hover': {
+            borderColor: '#90CAF9',
+            backgroundColor: 'rgba(144, 202, 249, 0.08)',
+          },
+        },
+      },
+    },
+    MuiSelect: {
+      styleOverrides: {
+        root: {
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#90CAF9',
+          },
+          '&:hover .MuiOutlinedInput-notchedOutline': {
+            borderColor: 'rgba(255, 255, 255, 0.23)',
+          },
+        },
+      },
+    },
+    MuiMenuItem: {
+      styleOverrides: {
+        root: {
+          '&.Mui-selected': {
+            backgroundColor: 'rgba(144, 202, 249, 0.16)',
+          },
+          '&.Mui-selected:hover': {
+            backgroundColor: 'rgba(144, 202, 249, 0.24)',
+          },
+          '&:hover': {
+            backgroundColor: 'rgba(255, 255, 255, 0.08)',
+          },
+        },
+      },
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: 12,
+          boxShadow: '0 1px 3px rgba(0, 0, 0, 0.5), 0 1px 2px rgba(0, 0, 0, 0.3)',
+          border: '1px solid rgba(255, 255, 255, 0.12)',
+          backgroundImage: 'none',
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+          boxShadow: '0 1px 3px rgba(0, 0, 0, 0.5), 0 1px 2px rgba(0, 0, 0, 0.3)',
+        },
+      },
+    },
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          boxShadow: '0 1px 3px rgba(0, 0, 0, 0.5)',
+          backgroundImage: 'none',
+          backgroundColor: '#1E1E1E',
+          borderBottom: '1px solid rgba(255, 255, 255, 0.12)',
+        },
+      },
+    },
+    MuiTableHead: {
+      styleOverrides: {
+        root: {
+          '& .MuiTableCell-root': {
+            fontWeight: 600,
+            color: '#FFFFFF',
+            backgroundColor: '#2A2A2A',
+            borderBottom: '2px solid rgba(255, 255, 255, 0.12)',
+          },
+        },
+      },
+    },
+    MuiTextField: {
+      styleOverrides: {
+        root: {
+          '& .MuiOutlinedInput-root': {
+            '& fieldset': {
+              borderColor: 'rgba(255, 255, 255, 0.23)',
+            },
+            '&:hover fieldset': {
+              borderColor: 'rgba(255, 255, 255, 0.4)',
+            },
+            '&.Mui-focused fieldset': {
+              borderColor: '#90CAF9',
+            },
+          },
+        },
+      },
+    },
+    MuiChip: {
+      styleOverrides: {
+        root: {
+          fontWeight: 500,
+        },
+      },
+    },
+  },
+});

--- a/client/src/themes/index.ts
+++ b/client/src/themes/index.ts
@@ -1,6 +1,5 @@
 import { lightTheme } from './lightTheme';
+import { darkTheme } from './darkTheme';
 
-// Export the light theme as the default and only theme
-export const theme = lightTheme;
-
-export { lightTheme };
+// Export both themes
+export { lightTheme, darkTheme };


### PR DESCRIPTION
## Summary
- Implemented theme switcher with sun/moon icons in user dropdown menu
- Added Material UI default dark theme (#121212 background)
- Theme preference persists to localStorage across sessions

## Implementation Details

### Theme Management
- Created enhanced `ThemeContext` with theme switching functionality
- Added `darkTheme.ts` with Material UI default dark theme configuration
- Theme state management with localStorage persistence using key `theme-mode`

### UI Changes
- Added theme toggle option in `CustomUserButton` dropdown menu
- Shows sun icon when in dark mode, moon icon when in light mode
- Toggle text changes between "Light mode" and "Dark mode" based on current theme

### Code Fixes
- Fixed Grid component import for MUI v7 compatibility in HomePage
- Removed unused Theme import from Login component

## Test Plan
- [x] Theme switcher appears in user dropdown menu
- [x] Clicking theme toggle switches between light and dark themes
- [x] Theme preference persists after page refresh
- [x] Dark theme uses Material UI default dark gray (#121212)
- [x] Sun/moon icons display correctly based on current theme
- [x] Application builds without errors
- [x] Linting passes (warnings only, no errors)

🤖 Generated with [Claude Code](https://claude.ai/code)