### PR TITLE
SCRUM-84: Add email domain validation for @honeycombsoft.com

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,145 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a multi-tenant SaaS application with three main components:
+- **API**: NestJS backend with TypeORM and PostgreSQL
+- **Client**: React frontend with Material UI, Clerk auth, and Zustand state management  
+- **Landing**: Landing page with SSR support
+
+## Development Commands
+
+### Quick Start
+```bash
+# Start all services with Docker Compose
+docker-compose up
+
+# Or run services individually:
+# API (runs on port 5000)
+cd api && npm run start:dev
+
+# Client (runs on port 3000)
+cd client && npm run dev
+
+# Landing (runs on port 3001)
+cd landing && npm run dev:ssr
+```
+
+### API Commands
+```bash
+cd api
+npm run build              # Build for production
+npm run start:dev          # Start with hot reload and linting
+npm run start:prod         # Start production build
+npm run lint               # Run ESLint and fix issues
+npm run test               # Run unit tests
+npm run test:e2e           # Run e2e tests
+npm run migration:generate # Generate TypeORM migration
+npm run migration:run      # Run migrations
+npm run migration:revert   # Revert last migration
+```
+
+### Client Commands  
+```bash
+cd client
+npm run dev                # Start dev server with linting
+npm run build              # Build for production
+npm run lint               # Run ESLint
+npm run lint:fix           # Fix ESLint issues
+npm run format             # Format code with Prettier
+npm run test               # Run tests
+```
+
+### Landing Commands
+```bash
+cd landing
+npm run dev                # Start dev server
+npm run dev:ssr            # Start SSR dev server
+npm run build:ssr          # Build for SSR production
+npm run lint               # Run ESLint
+npm run test               # Run tests
+```
+
+## Architecture
+
+### API Architecture (Clean Architecture)
+
+The API follows clean architecture with strict layer separation:
+
+```
+src/
+├── api/                   # Presentation Layer - Controllers, HTTP handling
+├── application/           # Application Layer - Use cases, CQRS, DTOs
+├── domain/               # Domain Layer - Entities, business logic, interfaces
+└── infrastructure/       # Infrastructure Layer - External services, persistence
+```
+
+**Key principles:**
+- Dependencies flow inward: API → Application → Domain
+- Domain layer has no external dependencies
+- Use dependency injection for service management
+- CQRS pattern for commands (state changes) and queries (reads)
+- Repository pattern with interfaces in domain, implementations in infrastructure
+
+### Client Architecture
+
+Feature-based module structure:
+```
+src/
+├── modules/              # Feature modules (auth, invoices, tenants, users)
+│   └── [feature]/
+│       ├── components/   # UI components
+│       ├── services/     # API calls
+│       ├── stores/       # Zustand state management
+│       └── types/        # TypeScript types
+├── common/               # Shared components and utilities
+└── routes/               # React Router configuration
+```
+
+### Database
+
+PostgreSQL with TypeORM migrations. Key entities:
+- Tenant (multi-tenancy support)
+- User (with Clerk integration)
+- Role (authorization)
+- Invoice & InvoiceItem (business domain)
+
+### Authentication & Security
+
+- **Authentication**: Clerk (external service)
+- **Authorization**: Role-based guards in API layer
+- **Multi-tenancy**: Tenant isolation at database level
+- **Secrets Management**: Support for AWS Secrets Manager, Azure Key Vault, or local storage
+
+### AI/LLM Integration
+
+The API includes Model Context Protocol (MCP) integration and supports OpenAI for AI-driven features, particularly for invoice data extraction and analysis.
+
+## Important Conventions
+
+- **TypeScript strict mode** enabled in all projects
+- **ESLint** runs before dev server starts - fix linting issues first
+- **Feature modules** maintain their own services, stores, and components
+- **Clean architecture layers** must be respected in the API
+- **Multi-tenant context** required for most API operations
+- **Clerk authentication** tokens required for API access
+
+## Environment Variables
+
+### API
+- Database connection via TypeORM config
+- Clerk API keys for authentication
+- Cloud provider secrets (AWS/Azure) if using cloud secret storage
+
+### Client
+- `VITE_API_URL` - Backend API URL
+- `VITE_CLERK_PUBLISHABLE_KEY` - Clerk public key
+
+## Testing Strategy
+
+- **Unit tests**: Focus on domain logic and use cases
+- **Integration tests**: Test repository implementations
+- **E2E tests**: Full API endpoint testing
+- All projects use Jest with `--passWithNoTests` flag

--- a/api/src/application/users/dto/create-user.dto.ts
+++ b/api/src/application/users/dto/create-user.dto.ts
@@ -9,15 +9,17 @@ import {
     ArrayMinSize,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsHoneycombSoftEmail } from '../validators/email-domain.validator';
 
 export class CreateUserDto {
     @ApiProperty({
-        description: 'Email address of the user',
-        example: 'user@example.com',
+        description: 'Email address of the user (must be from @honeycombsoft.com domain)',
+        example: 'user@honeycombsoft.com',
         maxLength: 255,
     })
     @IsNotEmpty()
     @IsEmail()
+    @IsHoneycombSoftEmail()
     @MaxLength(255)
     email: string;
 

--- a/api/src/application/users/dto/update-user.dto.ts
+++ b/api/src/application/users/dto/update-user.dto.ts
@@ -8,16 +8,18 @@ import {
     IsNotEmpty,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsHoneycombSoftEmail } from '../validators/email-domain.validator';
 
 export class UpdateUserDto {
     @ApiProperty({
-        description: 'Email address of the user',
-        example: 'updated@example.com',
+        description: 'Email address of the user (must be from @honeycombsoft.com domain)',
+        example: 'updated@honeycombsoft.com',
         required: false,
         maxLength: 255,
     })
     @IsOptional()
     @IsEmail()
+    @IsHoneycombSoftEmail()
     @MaxLength(255)
     email?: string;
 

--- a/api/src/application/users/validators/email-domain.validator.ts
+++ b/api/src/application/users/validators/email-domain.validator.ts
@@ -1,0 +1,39 @@
+import {
+    registerDecorator,
+    ValidationOptions,
+    ValidatorConstraint,
+    ValidatorConstraintInterface,
+} from 'class-validator';
+
+@ValidatorConstraint({ name: 'isHoneycombSoftEmail', async: false })
+export class IsHoneycombSoftEmailConstraint implements ValidatorConstraintInterface {
+    validate(email: string): boolean {
+        if (!email || typeof email !== 'string') {
+            return false;
+        }
+
+        // Check for valid email format first
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailRegex.test(email)) {
+            return false;
+        }
+
+        return email.toLowerCase().endsWith('@honeycombsoft.com');
+    }
+
+    defaultMessage(): string {
+        return 'Email must be from @honeycombsoft.com domain';
+    }
+}
+
+export function IsHoneycombSoftEmail(validationOptions?: ValidationOptions) {
+    return function (object: object, propertyName: string) {
+        registerDecorator({
+            target: object.constructor,
+            propertyName: propertyName,
+            options: validationOptions,
+            constraints: [],
+            validator: IsHoneycombSoftEmailConstraint,
+        });
+    };
+}

--- a/client/src/modules/users/components/UserForm.tsx
+++ b/client/src/modules/users/components/UserForm.tsx
@@ -56,7 +56,17 @@ const generateUserSchema = (allRoles: Role[]) =>
   Yup.object().shape({
     firstName: Yup.string().max(100, 'Too Long!').optional(),
     lastName: Yup.string().max(100, 'Too Long!').optional(),
-    email: Yup.string().email('Invalid email').max(255).required('Required'),
+    email: Yup.string()
+      .email('Invalid email')
+      .max(255)
+      .required('Required')
+      .test('honeycombsoft-domain', 'Email must be from @honeycombsoft.com domain', (value) => {
+        if (!value) return false;
+        // Ensure it's a valid email format first
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailRegex.test(value)) return false;
+        return value.toLowerCase().endsWith('@honeycombsoft.com');
+      }),
     tenantId: Yup.string().when(['roleIds', '$isSuperAdmin'], {
       is: (roleIds: string[], isContextSuperAdmin: boolean) => {
         const superAdminRole = allRoles?.find((r) => r.name === ROLES.SUPER_ADMIN);
@@ -243,8 +253,9 @@ const UserForm: React.FC<UserFormProps> = ({ user, onClose }) => {
                 fullWidth
                 required
                 disabled={isEditing}
+                placeholder="user@honeycombsoft.com"
                 error={touched.email && !!errors.email}
-                helperText={touched.email && errors.email}
+                helperText={touched.email && errors.email || (!touched.email && !isEditing && 'Must be from @honeycombsoft.com domain')}
               />
 
               {isSuperAdmin && (


### PR DESCRIPTION
## Summary
- Implemented email domain validation to accept only @honeycombsoft.com email addresses
- Added validation on both frontend (Yup) and backend (class-validator) layers
- All users (including super admins) must use @honeycombsoft.com emails

## Changes
- Created custom `IsHoneycombSoftEmail` validator decorator for backend DTOs
- Updated `CreateUserDto` and `UpdateUserDto` with domain validation
- Added Yup validation test in `UserForm` component for frontend validation
- Added helpful placeholder and error messages to guide users
- Validation is case-insensitive and checks for proper email format

## Test plan
- [ ] Create a new user with @honeycombsoft.com email - should succeed
- [ ] Try to create a user with @gmail.com email - should show validation error
- [ ] Try to update a user with non-honeycombsoft.com email - should show validation error
- [ ] Verify error message displays: "Email must be from @honeycombsoft.com domain"
- [ ] Test with mixed case emails (e.g., user@HoneyCombSoft.com) - should succeed

🤖 Generated with [Claude Code](https://claude.ai/code)