### PR TITLE
SCRUM-55: Add theme switcher with neon green and neon pink themes

### DIFF
--- a/client/src/common/components/MainLayout.tsx
+++ b/client/src/common/components/MainLayout.tsx
@@ -20,6 +20,7 @@ import {
 import { Theme } from '@mui/material/styles';
 import MenuIcon from '@mui/icons-material/Menu';
 import CustomUserButton from './CustomUserButton';
+import ThemeToggle from './ThemeToggle';
 import useUserRoles from '../hooks/useUserRoles';
 import { ROLES } from '../constants/roles';
 import InvoiceFileUpload from '../../modules/invoices/components/InvoiceFileUpload';
@@ -151,6 +152,8 @@ const MainLayout: React.FC = () => {
                 </Button>
               ))}
             </Box>
+
+            <ThemeToggle />
 
             <Box sx={{ ml: { xs: 1, md: 2 } }}>
               <CustomUserButton afterSignOutUrl="/" />

--- a/client/src/common/components/ThemeToggle.tsx
+++ b/client/src/common/components/ThemeToggle.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { IconButton, Tooltip } from '@mui/material';
+import Brightness4Icon from '@mui/icons-material/Brightness4';
+import Brightness7Icon from '@mui/icons-material/Brightness7';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import { useTheme } from '../../themes/useTheme';
+
+const ThemeToggle: React.FC = () => {
+  const { themeMode, toggleTheme } = useTheme();
+
+  const getThemeIcon = () => {
+    switch (themeMode) {
+      case 'neon-green':
+        return <AutoAwesomeIcon sx={{ color: '#00FF00' }} />;
+      case 'neon-pink':
+        return <AutoAwesomeIcon sx={{ color: '#FF4DFF' }} />;
+      case 'light':
+        return <Brightness7Icon />;
+      case 'dark':
+        return <Brightness4Icon />;
+      default:
+        return <AutoAwesomeIcon />;
+    }
+  };
+
+  const getTooltipText = () => {
+    if (themeMode === 'neon-green') return 'Switch to Neon Pink theme';
+    if (themeMode === 'neon-pink') return 'Switch to Neon Green theme';
+    return themeMode === 'light' ? 'Switch to dark mode' : 'Switch to light mode';
+  };
+
+  return (
+    <Tooltip title={getTooltipText()} arrow>
+      <IconButton
+        onClick={toggleTheme}
+        color="inherit"
+        aria-label={getTooltipText()}
+        sx={{
+          ml: 1,
+          transition: 'transform 0.3s ease',
+          '&:hover': {
+            transform: 'rotate(180deg)',
+          },
+        }}
+      >
+        {getThemeIcon()}
+      </IconButton>
+    </Tooltip>
+  );
+};
+
+export default ThemeToggle;

--- a/client/src/themes/ThemeContext.tsx
+++ b/client/src/themes/ThemeContext.tsx
@@ -1,12 +1,15 @@
 import React, { ReactNode, useState, useEffect, useMemo } from 'react';
 import { ThemeProvider as MuiThemeProvider } from '@mui/material';
 import { darkTheme, lightTheme } from './index';
+import { neonDarkGreenTheme } from './neonDarkGreenTheme';
+import { neonPinkyDarkTheme } from './neonPinkyDarkTheme';
 import { ThemeContext, ThemeMode, THEME_STORAGE_KEY } from './context';
 
 export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [themeMode, setThemeMode] = useState<ThemeMode>(() => {
-    const savedTheme = localStorage.getItem(THEME_STORAGE_KEY);
-    return savedTheme === 'light' || savedTheme === 'dark' ? savedTheme : 'dark';
+    const savedTheme = localStorage.getItem(THEME_STORAGE_KEY) as ThemeMode;
+    const validThemes: ThemeMode[] = ['light', 'dark', 'neon-green', 'neon-pink'];
+    return validThemes.includes(savedTheme) ? savedTheme : 'neon-green';
   });
 
   useEffect(() => {
@@ -14,16 +17,36 @@ export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) =
   }, [themeMode]);
 
   const toggleTheme = () => {
-    setThemeMode(prevMode => prevMode === 'light' ? 'dark' : 'light');
+    setThemeMode(prevMode => {
+      if (prevMode === 'neon-green') return 'neon-pink';
+      if (prevMode === 'neon-pink') return 'neon-green';
+      return prevMode === 'light' ? 'dark' : 'light';
+    });
+  };
+
+  const setTheme = (theme: ThemeMode) => {
+    setThemeMode(theme);
   };
 
   const theme = useMemo(() => {
-    return themeMode === 'light' ? lightTheme : darkTheme;
+    switch (themeMode) {
+      case 'light':
+        return lightTheme;
+      case 'dark':
+        return darkTheme;
+      case 'neon-green':
+        return neonDarkGreenTheme;
+      case 'neon-pink':
+        return neonPinkyDarkTheme;
+      default:
+        return neonDarkGreenTheme;
+    }
   }, [themeMode]);
 
   const contextValue = useMemo(() => ({
     themeMode,
     toggleTheme,
+    setTheme,
   }), [themeMode]);
 
   return (

--- a/client/src/themes/context.ts
+++ b/client/src/themes/context.ts
@@ -1,12 +1,13 @@
 import { createContext } from 'react';
 
-export type ThemeMode = 'light' | 'dark';
+export type ThemeMode = 'light' | 'dark' | 'neon-green' | 'neon-pink';
 
 export interface ThemeContextType {
   themeMode: ThemeMode;
   toggleTheme: () => void;
+  setTheme: (theme: ThemeMode) => void;
 }
 
 export const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
-export const THEME_STORAGE_KEY = 'theme-preference';
+export const THEME_STORAGE_KEY = 'app_theme';

--- a/client/src/themes/neonDarkGreenTheme.ts
+++ b/client/src/themes/neonDarkGreenTheme.ts
@@ -1,0 +1,192 @@
+import { createTheme } from '@mui/material';
+
+export const neonDarkGreenTheme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: {
+      main: '#00FF00',
+      light: '#66FF66',
+      dark: '#00CC00',
+      contrastText: '#000000',
+    },
+    secondary: {
+      main: '#00FF88',
+      light: '#66FFAA',
+      dark: '#00CC66',
+      contrastText: '#000000',
+    },
+    background: {
+      default: '#001100',
+      paper: '#002200',
+    },
+    text: {
+      primary: '#E6FFE6',
+      secondary: '#99FF99',
+    },
+    error: {
+      main: '#FF4444',
+    },
+    warning: {
+      main: '#FFAA00',
+    },
+    info: {
+      main: '#00AAFF',
+    },
+    success: {
+      main: '#00FF00',
+    },
+    divider: 'rgba(0, 255, 0, 0.12)',
+  },
+  typography: {
+    fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
+    h1: {
+      fontWeight: 700,
+    },
+    h2: {
+      fontWeight: 700,
+    },
+    h3: {
+      fontWeight: 600,
+    },
+    h4: {
+      fontWeight: 600,
+    },
+    h5: {
+      fontWeight: 600,
+    },
+    h6: {
+      fontWeight: 600,
+    },
+    button: {
+      fontWeight: 600,
+      textTransform: 'none',
+    },
+  },
+  shape: {
+    borderRadius: 8,
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          boxShadow: '0 0 10px rgba(0, 255, 0, 0.3)',
+          padding: '8px 16px',
+          transition: 'all 0.2s ease',
+          '&:hover': {
+            boxShadow: '0 0 20px rgba(0, 255, 0, 0.5)',
+            transform: 'translateY(-1px)',
+          },
+        },
+        contained: {
+          backgroundColor: '#00FF00',
+          color: '#000000',
+          '&:hover': {
+            backgroundColor: '#00CC00',
+          },
+        },
+        outlined: {
+          borderColor: 'rgba(0, 255, 0, 0.5)',
+          color: '#00FF00',
+          '&:hover': {
+            borderColor: '#00FF00',
+            backgroundColor: 'rgba(0, 255, 0, 0.08)',
+          },
+        },
+      },
+    },
+    MuiSelect: {
+      styleOverrides: {
+        root: {
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#00FF00',
+          },
+          '&:hover .MuiOutlinedInput-notchedOutline': {
+            borderColor: 'rgba(0, 255, 0, 0.5)',
+          },
+        },
+      },
+    },
+    MuiMenuItem: {
+      styleOverrides: {
+        root: {
+          '&.Mui-selected': {
+            backgroundColor: 'rgba(0, 255, 0, 0.16)',
+          },
+          '&.Mui-selected:hover': {
+            backgroundColor: 'rgba(0, 255, 0, 0.24)',
+          },
+          '&:hover': {
+            backgroundColor: 'rgba(0, 255, 0, 0.08)',
+          },
+        },
+      },
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: 12,
+          boxShadow: '0 0 20px rgba(0, 255, 0, 0.1)',
+          border: '1px solid rgba(0, 255, 0, 0.2)',
+          backgroundImage: 'none',
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+          boxShadow: '0 0 15px rgba(0, 255, 0, 0.1)',
+        },
+      },
+    },
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          boxShadow: '0 0 15px rgba(0, 255, 0, 0.2)',
+          backgroundImage: 'none',
+          backgroundColor: '#002200',
+          borderBottom: '1px solid rgba(0, 255, 0, 0.2)',
+        },
+      },
+    },
+    MuiTableHead: {
+      styleOverrides: {
+        root: {
+          '& .MuiTableCell-root': {
+            fontWeight: 600,
+            color: '#E6FFE6',
+            backgroundColor: '#003300',
+            borderBottom: '2px solid rgba(0, 255, 0, 0.2)',
+          },
+        },
+      },
+    },
+    MuiTextField: {
+      styleOverrides: {
+        root: {
+          '& .MuiOutlinedInput-root': {
+            '& fieldset': {
+              borderColor: 'rgba(0, 255, 0, 0.3)',
+            },
+            '&:hover fieldset': {
+              borderColor: 'rgba(0, 255, 0, 0.5)',
+            },
+            '&.Mui-focused fieldset': {
+              borderColor: '#00FF00',
+              boxShadow: '0 0 5px rgba(0, 255, 0, 0.3)',
+            },
+          },
+        },
+      },
+    },
+    MuiChip: {
+      styleOverrides: {
+        root: {
+          fontWeight: 500,
+          borderColor: 'rgba(0, 255, 0, 0.3)',
+        },
+      },
+    },
+  },
+});

--- a/client/src/themes/neonPinkyDarkTheme.ts
+++ b/client/src/themes/neonPinkyDarkTheme.ts
@@ -1,0 +1,192 @@
+import { createTheme } from '@mui/material';
+
+export const neonPinkyDarkTheme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: {
+      main: '#FF4DFF',
+      light: '#FF99FF',
+      dark: '#CC00CC',
+      contrastText: '#000000',
+    },
+    secondary: {
+      main: '#FF99FF',
+      light: '#FFCCFF',
+      dark: '#CC66CC',
+      contrastText: '#000000',
+    },
+    background: {
+      default: '#0B0010',
+      paper: '#140019',
+    },
+    text: {
+      primary: '#FFE6FF',
+      secondary: '#FF99FF',
+    },
+    error: {
+      main: '#FF4444',
+    },
+    warning: {
+      main: '#FFAA00',
+    },
+    info: {
+      main: '#AA88FF',
+    },
+    success: {
+      main: '#FF88DD',
+    },
+    divider: 'rgba(255, 77, 255, 0.12)',
+  },
+  typography: {
+    fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
+    h1: {
+      fontWeight: 700,
+    },
+    h2: {
+      fontWeight: 700,
+    },
+    h3: {
+      fontWeight: 600,
+    },
+    h4: {
+      fontWeight: 600,
+    },
+    h5: {
+      fontWeight: 600,
+    },
+    h6: {
+      fontWeight: 600,
+    },
+    button: {
+      fontWeight: 600,
+      textTransform: 'none',
+    },
+  },
+  shape: {
+    borderRadius: 8,
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          boxShadow: '0 0 10px rgba(255, 77, 255, 0.3)',
+          padding: '8px 16px',
+          transition: 'all 0.2s ease',
+          '&:hover': {
+            boxShadow: '0 0 20px rgba(255, 77, 255, 0.5)',
+            transform: 'translateY(-1px)',
+          },
+        },
+        contained: {
+          backgroundColor: '#FF4DFF',
+          color: '#000000',
+          '&:hover': {
+            backgroundColor: '#CC00CC',
+          },
+        },
+        outlined: {
+          borderColor: 'rgba(255, 77, 255, 0.5)',
+          color: '#FF4DFF',
+          '&:hover': {
+            borderColor: '#FF4DFF',
+            backgroundColor: 'rgba(255, 77, 255, 0.08)',
+          },
+        },
+      },
+    },
+    MuiSelect: {
+      styleOverrides: {
+        root: {
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#FF4DFF',
+          },
+          '&:hover .MuiOutlinedInput-notchedOutline': {
+            borderColor: 'rgba(255, 77, 255, 0.5)',
+          },
+        },
+      },
+    },
+    MuiMenuItem: {
+      styleOverrides: {
+        root: {
+          '&.Mui-selected': {
+            backgroundColor: 'rgba(255, 77, 255, 0.16)',
+          },
+          '&.Mui-selected:hover': {
+            backgroundColor: 'rgba(255, 77, 255, 0.24)',
+          },
+          '&:hover': {
+            backgroundColor: 'rgba(255, 77, 255, 0.08)',
+          },
+        },
+      },
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: 12,
+          boxShadow: '0 0 20px rgba(255, 77, 255, 0.1)',
+          border: '1px solid rgba(255, 77, 255, 0.2)',
+          backgroundImage: 'none',
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+          boxShadow: '0 0 15px rgba(255, 77, 255, 0.1)',
+        },
+      },
+    },
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          boxShadow: '0 0 15px rgba(255, 77, 255, 0.2)',
+          backgroundImage: 'none',
+          backgroundColor: '#140019',
+          borderBottom: '1px solid rgba(255, 77, 255, 0.2)',
+        },
+      },
+    },
+    MuiTableHead: {
+      styleOverrides: {
+        root: {
+          '& .MuiTableCell-root': {
+            fontWeight: 600,
+            color: '#FFE6FF',
+            backgroundColor: '#1A0020',
+            borderBottom: '2px solid rgba(255, 77, 255, 0.2)',
+          },
+        },
+      },
+    },
+    MuiTextField: {
+      styleOverrides: {
+        root: {
+          '& .MuiOutlinedInput-root': {
+            '& fieldset': {
+              borderColor: 'rgba(255, 77, 255, 0.3)',
+            },
+            '&:hover fieldset': {
+              borderColor: 'rgba(255, 77, 255, 0.5)',
+            },
+            '&.Mui-focused fieldset': {
+              borderColor: '#FF4DFF',
+              boxShadow: '0 0 5px rgba(255, 77, 255, 0.3)',
+            },
+          },
+        },
+      },
+    },
+    MuiChip: {
+      styleOverrides: {
+        root: {
+          fontWeight: 500,
+          borderColor: 'rgba(255, 77, 255, 0.3)',
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Added a theme switcher that toggles between Neon Dark Green and Neon Pinky Dark themes
- Themes persist across sessions using localStorage
- Accessible with keyboard navigation and tooltips

## Implementation Details
- Created two MUI theme objects: `neonDarkGreenTheme` and `neonPinkyDarkTheme`
- Updated ThemeProvider to support new themes with localStorage persistence (key: `app_theme`)
- Added ThemeToggle component with icon button in the header
- Default theme is set to neon-green

## Test Plan
- [ ] Open the Client app
- [ ] Click the theme toggle button in the header
- [ ] Verify theme switches between neon green and neon pink
- [ ] Refresh the page and verify the theme persists
- [ ] Test keyboard navigation (Tab to button, Enter/Space to toggle)
- [ ] Verify tooltips appear on hover