### PR TITLE
AD5-88: Add tenant filter for Super Admin users in User Management table

### DIFF
--- a/client/src/modules/users/stores/userManagementStore.ts
+++ b/client/src/modules/users/stores/userManagementStore.ts
@@ -15,6 +15,7 @@ interface UserManagementState {
   emailFilter: string;
   roleFilter: string;
   statusFilter: StatusFilter;
+  tenantFilter: string;
 
   openCreateForm: () => void;
   openEditForm: (user: User) => void;
@@ -32,6 +33,7 @@ interface UserManagementState {
   setEmailFilter: (email: string) => void;
   setRoleFilter: (role: string) => void;
   setStatusFilter: (status: StatusFilter) => void;
+  setTenantFilter: (tenant: string) => void;
   clearFilters: () => void;
 }
 
@@ -48,6 +50,7 @@ export const useUserManagementStore = create<UserManagementState>((set) => ({
   emailFilter: '',
   roleFilter: '',
   statusFilter: 'all',
+  tenantFilter: '',
 
   openCreateForm: (): void => set({ isFormOpen: true, selectedUser: null }),
   openEditForm: (user: User): void => set({ isFormOpen: true, selectedUser: user }),
@@ -70,6 +73,7 @@ export const useUserManagementStore = create<UserManagementState>((set) => ({
   setEmailFilter: (email: string): void => set({ emailFilter: email }),
   setRoleFilter: (role: string): void => set({ roleFilter: role }),
   setStatusFilter: (status: StatusFilter): void => set({ statusFilter: status }),
+  setTenantFilter: (tenant: string): void => set({ tenantFilter: tenant }),
   clearFilters: (): void =>
-    set({ emailFilter: '', roleFilter: '', statusFilter: 'all' }),
+    set({ emailFilter: '', roleFilter: '', statusFilter: 'all', tenantFilter: '' }),
 }));

--- a/client/src/modules/users/user-management/UserManagementPage.tsx
+++ b/client/src/modules/users/user-management/UserManagementPage.tsx
@@ -308,7 +308,7 @@ const UserManagementPage: React.FC<UserManagementPageProps> = () => {
                     {isSuperAdmin && (
                       <TableCell>
                         <Stack spacing={1}>
-                          <Typography variant="body2">tenant</Typography>
+                          <Typography variant="body2">Tenant</Typography>
                           <FormControl size="small" sx={{ minWidth: 120 }}>
                             <Select
                               value={tenantFilter}

--- a/client/src/modules/users/user-management/UserManagementPage.tsx
+++ b/client/src/modules/users/user-management/UserManagementPage.tsx
@@ -308,7 +308,7 @@ const UserManagementPage: React.FC<UserManagementPageProps> = () => {
                     {isSuperAdmin && (
                       <TableCell>
                         <Stack spacing={1}>
-                          <Typography variant="body2">Tenant</Typography>
+                          <Typography variant="body2">tenant</Typography>
                           <FormControl size="small" sx={{ minWidth: 120 }}>
                             <Select
                               value={tenantFilter}

--- a/client/src/modules/users/user-management/UserManagementPage.tsx
+++ b/client/src/modules/users/user-management/UserManagementPage.tsx
@@ -308,7 +308,7 @@ const UserManagementPage: React.FC<UserManagementPageProps> = () => {
                     {isSuperAdmin && (
                       <TableCell>
                         <Stack spacing={1}>
-                          <Typography variant="body2">Tenant</Typography>
+                          <Typography variant="body2">TENANT</Typography>
                           <FormControl size="small" sx={{ minWidth: 120 }}>
                             <Select
                               value={tenantFilter}

--- a/client/src/modules/users/user-management/UserManagementPage.tsx
+++ b/client/src/modules/users/user-management/UserManagementPage.tsx
@@ -80,6 +80,7 @@ const UserManagementPage: React.FC<UserManagementPageProps> = () => {
     emailFilter,
     roleFilter,
     statusFilter,
+    tenantFilter,
     openCreateForm,
     openEditForm,
     closeForm,
@@ -92,6 +93,7 @@ const UserManagementPage: React.FC<UserManagementPageProps> = () => {
     setEmailFilter,
     setRoleFilter,
     setStatusFilter,
+    setTenantFilter,
     clearFilters,
   } = useUserManagementStore();
 
@@ -126,6 +128,17 @@ const UserManagementPage: React.FC<UserManagementPageProps> = () => {
     return Array.from(rolesSet).sort();
   }, [users]);
 
+  // Get unique tenants for filter dropdown
+  const availableTenants = useMemo(() => {
+    const tenantsSet = new Set<string>();
+    users.forEach((user) => {
+      if (user.tenant?.name) {
+        tenantsSet.add(user.tenant.name);
+      }
+    });
+    return Array.from(tenantsSet).sort();
+  }, [users]);
+
   // Apply client-side filtering
   const filteredUsers = useMemo(() => {
     let result = [...users];
@@ -151,10 +164,17 @@ const UserManagementPage: React.FC<UserManagementPageProps> = () => {
       );
     }
 
-    return result;
-  }, [users, emailFilter, roleFilter, statusFilter]);
+    // Filter by tenant
+    if (tenantFilter) {
+      result = result.filter((user) =>
+        user.tenant?.name === tenantFilter,
+      );
+    }
 
-  const hasActiveFilters = emailFilter || roleFilter || statusFilter !== 'all';
+    return result;
+  }, [users, emailFilter, roleFilter, statusFilter, tenantFilter]);
+
+  const hasActiveFilters = emailFilter || roleFilter || statusFilter !== 'all' || tenantFilter;
 
   const { mutateAsync: removeUserMutate, isPending: isDeleting } = useMutation({
     mutationFn: deleteUser,
@@ -285,7 +305,30 @@ const UserManagementPage: React.FC<UserManagementPageProps> = () => {
                       </Stack>
                     </TableCell>
                     <TableCell>Name</TableCell>
-                    {isSuperAdmin && <TableCell>Tenant</TableCell>}
+                    {isSuperAdmin && (
+                      <TableCell>
+                        <Stack spacing={1}>
+                          <Typography variant="body2">Tenant</Typography>
+                          <FormControl size="small" sx={{ minWidth: 120 }}>
+                            <Select
+                              value={tenantFilter}
+                              onChange={(e: SelectChangeEvent) => setTenantFilter(e.target.value)}
+                              displayEmpty
+                              sx={{
+                                backgroundColor: theme.palette.background.default,
+                              }}
+                            >
+                              <MenuItem value="">All Tenants</MenuItem>
+                              {availableTenants.map((tenant) => (
+                                <MenuItem key={tenant} value={tenant}>
+                                  {tenant}
+                                </MenuItem>
+                              ))}
+                            </Select>
+                          </FormControl>
+                        </Stack>
+                      </TableCell>
+                    )}
                     <TableCell>
                       <Stack spacing={1}>
                         <Typography variant="body2">Roles</Typography>

--- a/client/src/modules/users/user-management/UserManagementPage.tsx
+++ b/client/src/modules/users/user-management/UserManagementPage.tsx
@@ -308,7 +308,7 @@ const UserManagementPage: React.FC<UserManagementPageProps> = () => {
                     {isSuperAdmin && (
                       <TableCell>
                         <Stack spacing={1}>
-                          <Typography variant="body2">TENANT</Typography>
+                          <Typography variant="body2">tenant</Typography>
                           <FormControl size="small" sx={{ minWidth: 120 }}>
                             <Select
                               value={tenantFilter}


### PR DESCRIPTION
## Summary
- Added tenant filter dropdown to User Management table (visible only to Super Admin users)
- Integrated with existing filters using AND logic for comprehensive filtering
- Enhanced user management capabilities for multi-tenant environments

## Test plan
- [ ] Verify tenant filter appears only for Super Admin users
- [ ] Test filtering by tenant works correctly
- [ ] Confirm AND logic works with multiple filters (email + role + status + tenant)
- [ ] Verify clear filters button resets all filters including tenant
- [ ] Test with different tenant names and edge cases