### PR TITLE
AD5-72: Add filters to the User Management table

### DIFF
--- a/client/src/modules/users/stores/userManagementStore.ts
+++ b/client/src/modules/users/stores/userManagementStore.ts
@@ -1,8 +1,6 @@
 import { create } from 'zustand';
 import { User } from '../types/user';
 
-export type StatusFilter = 'all' | 'active' | 'inactive';
-
 interface UserManagementState {
   isFormOpen: boolean;
   selectedUser: User | null;
@@ -12,9 +10,7 @@ interface UserManagementState {
   userToToggleStatus: User | null;
 
   // Filter states
-  emailFilter: string;
-  roleFilter: string;
-  statusFilter: StatusFilter;
+  searchTerm: string;
 
   openCreateForm: () => void;
   openEditForm: (user: User) => void;
@@ -29,9 +25,7 @@ interface UserManagementState {
   resetToggleStatusState: () => void;
 
   // Filter actions
-  setEmailFilter: (email: string) => void;
-  setRoleFilter: (role: string) => void;
-  setStatusFilter: (status: StatusFilter) => void;
+  setSearchTerm: (searchTerm: string) => void;
   clearFilters: () => void;
 }
 
@@ -45,9 +39,7 @@ export const useUserManagementStore = create<UserManagementState>((set) => ({
   userToToggleStatus: null,
 
   // Filter initial states
-  emailFilter: '',
-  roleFilter: '',
-  statusFilter: 'all',
+  searchTerm: '',
 
   openCreateForm: (): void => set({ isFormOpen: true, selectedUser: null }),
   openEditForm: (user: User): void => set({ isFormOpen: true, selectedUser: user }),
@@ -67,9 +59,6 @@ export const useUserManagementStore = create<UserManagementState>((set) => ({
     set({ isConfirmToggleStatusDialogOpen: false, userToToggleStatus: null }),
 
   // Filter actions
-  setEmailFilter: (email: string): void => set({ emailFilter: email }),
-  setRoleFilter: (role: string): void => set({ roleFilter: role }),
-  setStatusFilter: (status: StatusFilter): void => set({ statusFilter: status }),
-  clearFilters: (): void =>
-    set({ emailFilter: '', roleFilter: '', statusFilter: 'all' }),
+  setSearchTerm: (searchTerm: string): void => set({ searchTerm }),
+  clearFilters: (): void => set({ searchTerm: '' }),
 }));

--- a/client/src/modules/users/user-management/UserManagementPage.tsx
+++ b/client/src/modules/users/user-management/UserManagementPage.tsx
@@ -11,12 +11,8 @@ import {
   Dialog,
   DialogContent,
   DialogTitle,
-  FormControl,
   IconButton,
   InputAdornment,
-  MenuItem,
-  Select,
-  SelectChangeEvent,
   Stack,
   Table,
   TableBody,
@@ -44,7 +40,7 @@ import { ROLES } from '../../../common/constants/roles';
 import { getUsers } from '../userQueries.ts';
 import { deleteUser, activateUser, deactivateUser } from '../userMutations.ts';
 import { CACHE_TIMES } from '../../../common/constants/cacheTimes.ts';
-import { useUserManagementStore, StatusFilter } from '../stores/userManagementStore';
+import { useUserManagementStore } from '../stores/userManagementStore';
 import { USER_QUERY_KEYS } from '../userQueryKeys.ts';
 
 type UserManagementPageProps = Record<string, unknown>;
@@ -77,9 +73,7 @@ const UserManagementPage: React.FC<UserManagementPageProps> = () => {
     userToDeleteId,
     isConfirmToggleStatusDialogOpen,
     userToToggleStatus,
-    emailFilter,
-    roleFilter,
-    statusFilter,
+    searchTerm,
     openCreateForm,
     openEditForm,
     closeForm,
@@ -89,9 +83,7 @@ const UserManagementPage: React.FC<UserManagementPageProps> = () => {
     openConfirmToggleStatusDialog,
     closeConfirmToggleStatusDialog,
     resetToggleStatusState,
-    setEmailFilter,
-    setRoleFilter,
-    setStatusFilter,
+    setSearchTerm,
     clearFilters,
   } = useUserManagementStore();
 
@@ -115,46 +107,23 @@ const UserManagementPage: React.FC<UserManagementPageProps> = () => {
 
   const users = useMemo(() => usersData?.data ?? [], [usersData]);
 
-  // Get unique roles for filter dropdown
-  const availableRoles = useMemo(() => {
-    const rolesSet = new Set<string>();
-    users.forEach((user) => {
-      user.roles.forEach((role) => {
-        rolesSet.add(role.name);
-      });
-    });
-    return Array.from(rolesSet).sort();
-  }, [users]);
-
-  // Apply client-side filtering
+  // Apply client-side filtering for email and name
   const filteredUsers = useMemo(() => {
-    let result = [...users];
-
-    // Filter by email
-    if (emailFilter) {
-      result = result.filter((user) =>
-        user.email.toLowerCase().includes(emailFilter.toLowerCase()),
-      );
+    if (!searchTerm.trim()) {
+      return users;
     }
 
-    // Filter by role
-    if (roleFilter) {
-      result = result.filter((user) =>
-        user.roles.some((role) => role.name === roleFilter),
+    const searchLower = searchTerm.toLowerCase().trim();
+    return users.filter((user) => {
+      const fullName = `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim();
+      return (
+        user.email.toLowerCase().includes(searchLower) ||
+        fullName.toLowerCase().includes(searchLower)
       );
-    }
+    });
+  }, [users, searchTerm]);
 
-    // Filter by status
-    if (statusFilter !== 'all') {
-      result = result.filter((user) =>
-        statusFilter === 'active' ? user.isActive : !user.isActive,
-      );
-    }
-
-    return result;
-  }, [users, emailFilter, roleFilter, statusFilter]);
-
-  const hasActiveFilters = emailFilter || roleFilter || statusFilter !== 'all';
+  const hasActiveFilters = searchTerm.trim().length > 0;
 
   const { mutateAsync: removeUserMutate, isPending: isDeleting } = useMutation({
     mutationFn: deleteUser,
@@ -221,15 +190,45 @@ const UserManagementPage: React.FC<UserManagementPageProps> = () => {
             </Typography>
           }
           action={
-            <Button
-              variant="contained"
-              onClick={openCreateForm}
-              sx={{
-                backgroundColor: theme.palette.primary.main,
-                '&:hover': { backgroundColor: theme.palette.primary.dark },
-              }}>
-              + Add User
-            </Button>
+            <Stack direction="row" spacing={2} alignItems="center">
+              <TextField
+                size="small"
+                placeholder="Search by email or name..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <SearchIcon fontSize="small" />
+                    </InputAdornment>
+                  ),
+                  endAdornment: searchTerm && (
+                    <InputAdornment position="end">
+                      <IconButton
+                        size="small"
+                        onClick={() => setSearchTerm('')}
+                        edge="end"
+                      >
+                        <ClearIcon fontSize="small" />
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                  sx: {
+                    backgroundColor: theme.palette.background.default,
+                  },
+                }}
+                sx={{ minWidth: 250 }}
+              />
+              <Button
+                variant="contained"
+                onClick={openCreateForm}
+                sx={{
+                  backgroundColor: theme.palette.primary.main,
+                  '&:hover': { backgroundColor: theme.palette.primary.dark },
+                }}>
+                + Add User
+              </Button>
+            </Stack>
           }
         />
         <CardContent sx={{ p: 0, '&:last-child': { pb: 0 } }}>
@@ -251,94 +250,13 @@ const UserManagementPage: React.FC<UserManagementPageProps> = () => {
                         borderBottom: `1px solid ${theme.palette.divider}`,
                       },
                     }}>
-                    <TableCell>
-                      <Stack spacing={1}>
-                        <Typography variant="body2">Email</Typography>
-                        <TextField
-                          size="small"
-                          placeholder="Filter by email"
-                          value={emailFilter}
-                          onChange={(e) => setEmailFilter(e.target.value)}
-                          InputProps={{
-                            startAdornment: (
-                              <InputAdornment position="start">
-                                <SearchIcon fontSize="small" />
-                              </InputAdornment>
-                            ),
-                            endAdornment: emailFilter && (
-                              <InputAdornment position="end">
-                                <IconButton
-                                  size="small"
-                                  onClick={() => setEmailFilter('')}
-                                  edge="end"
-                                >
-                                  <ClearIcon fontSize="small" />
-                                </IconButton>
-                              </InputAdornment>
-                            ),
-                            sx: {
-                              backgroundColor: theme.palette.background.default,
-                            },
-                          }}
-                          sx={{ minWidth: 180 }}
-                        />
-                      </Stack>
-                    </TableCell>
+                    <TableCell>Email</TableCell>
                     <TableCell>Name</TableCell>
                     {isSuperAdmin && <TableCell>Tenant</TableCell>}
-                    <TableCell>
-                      <Stack spacing={1}>
-                        <Typography variant="body2">Roles</Typography>
-                        <FormControl size="small" sx={{ minWidth: 120 }}>
-                          <Select
-                            value={roleFilter}
-                            onChange={(e: SelectChangeEvent) => setRoleFilter(e.target.value)}
-                            displayEmpty
-                            sx={{
-                              backgroundColor: theme.palette.background.default,
-                            }}
-                          >
-                            <MenuItem value="">All Roles</MenuItem>
-                            {availableRoles.map((role) => (
-                              <MenuItem key={role} value={role}>
-                                {role}
-                              </MenuItem>
-                            ))}
-                          </Select>
-                        </FormControl>
-                      </Stack>
-                    </TableCell>
-                    <TableCell>
-                      <Stack spacing={1}>
-                        <Typography variant="body2">Status</Typography>
-                        <FormControl size="small" sx={{ minWidth: 120 }}>
-                          <Select
-                            value={statusFilter}
-                            onChange={(e: SelectChangeEvent) => setStatusFilter(e.target.value as StatusFilter)}
-                            sx={{
-                              backgroundColor: theme.palette.background.default,
-                            }}
-                          >
-                            <MenuItem value="all">All</MenuItem>
-                            <MenuItem value="active">Active Only</MenuItem>
-                            <MenuItem value="inactive">Inactive Only</MenuItem>
-                          </Select>
-                        </FormControl>
-                      </Stack>
-                    </TableCell>
+                    <TableCell>Roles</TableCell>
+                    <TableCell>Status</TableCell>
                     <TableCell>Created At</TableCell>
-                    <TableCell align="right">
-                      {hasActiveFilters && (
-                        <Button
-                          size="small"
-                          onClick={clearFilters}
-                          startIcon={<ClearIcon />}
-                          sx={{ mb: 1 }}
-                        >
-                          Clear Filters
-                        </Button>
-                      )}
-                    </TableCell>
+                    <TableCell align="right">Actions</TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody


### PR DESCRIPTION
## Summary
- Replace individual column filters with a single search bar for instant filtering
- Search filters email and name fields with case-insensitive matching
- Simplify User Management table header layout and remove unused filter components
- Remove StatusFilter type and related filtering logic from Zustand store

## Test plan
- [ ] Verify search bar appears in User Management page header
- [ ] Test instant search functionality for email filtering
- [ ] Test instant search functionality for name filtering (first name + last name)
- [ ] Confirm filter state resets on page reload
- [ ] Verify clear search functionality works correctly
- [ ] Check that table displays "No users match the current filters" when search returns no results