### PR TITLE
LEMON-19

### DIFF
--- a/client/src/common/components/CookieBanner.tsx
+++ b/client/src/common/components/CookieBanner.tsx
@@ -6,23 +6,28 @@ import {
   Button,
   Container,
   Stack,
-  Link,
   Slide,
+  FormGroup,
+  FormControlLabel,
+  Switch,
 } from '@mui/material';
 import { cookieManager } from '../utils/cookieManager';
 
 const CookieBanner: React.FC = () => {
   const [showBanner, setShowBanner] = useState(false);
+  const [showPreferences, setShowPreferences] = useState(false);
+  const [functional, setFunctional] = useState<boolean>(() => cookieManager.getPreferences()?.functional ?? true);
+  const [analytics, setAnalytics] = useState<boolean>(() => cookieManager.getPreferences()?.analytics ?? true);
+  const [thirdParty, setThirdParty] = useState<boolean>(() => cookieManager.getPreferences()?.thirdParty ?? true);
 
   useEffect(() => {
     const hasConsented = cookieManager.hasUserConsented();
     if (!hasConsented) {
       setShowBanner(true);
-      cookieManager.blockNonEssentialCookies();
     } else {
       const preferences = cookieManager.getPreferences();
       if (preferences?.consent === 'accepted') {
-        cookieManager.allowAllCookies();
+        cookieManager.applyPreferences(preferences);
       } else if (preferences?.consent === 'declined') {
         cookieManager.blockNonEssentialCookies();
       }
@@ -38,6 +43,15 @@ const CookieBanner: React.FC = () => {
   const handleDecline = () => {
     cookieManager.savePreferences('declined');
     cookieManager.blockNonEssentialCookies();
+    setShowBanner(false);
+  };
+
+  const handleSavePreferences = () => {
+    cookieManager.saveCategoryPreferences({
+      functional,
+      analytics,
+      thirdParty,
+    });
     setShowBanner(false);
   };
 
@@ -72,14 +86,6 @@ const CookieBanner: React.FC = () => {
                 We use cookies to enhance your experience, analyze site traffic, and serve personalized content.
                 This includes essential cookies for authentication (Clerk), functional cookies for site features,
                 analytics cookies for usage insights, and third-party cookies for enhanced functionality.
-                {' '}
-                <Link
-                  href="#"
-                  onClick={(e) => e.preventDefault()}
-                  sx={{ color: 'primary.main', textDecoration: 'underline' }}
-                >
-                  Learn more
-                </Link>
               </Typography>
             </Box>
             <Stack
@@ -104,6 +110,14 @@ const CookieBanner: React.FC = () => {
                 Decline
               </Button>
               <Button
+                variant="text"
+                onClick={() => setShowPreferences((prev) => !prev)}
+                size="large"
+                sx={{ minWidth: 120 }}
+              >
+                Preferences
+              </Button>
+              <Button
                 variant="contained"
                 onClick={handleAcceptAll}
                 size="large"
@@ -120,6 +134,47 @@ const CookieBanner: React.FC = () => {
               </Button>
             </Stack>
           </Stack>
+          {showPreferences && (
+            <Box mt={3}>
+              <FormGroup row>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={functional}
+                      onChange={(e) => setFunctional(e.target.checked)}
+                      color="primary"
+                    />
+                  }
+                  label="Functional cookies"
+                />
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={analytics}
+                      onChange={(e) => setAnalytics(e.target.checked)}
+                      color="primary"
+                    />
+                  }
+                  label="Analytics cookies"
+                />
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={thirdParty}
+                      onChange={(e) => setThirdParty(e.target.checked)}
+                      color="primary"
+                    />
+                  }
+                  label="Third-party cookies"
+                />
+              </FormGroup>
+              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ mt: 2 }}>
+                <Button variant="contained" onClick={handleSavePreferences} size="large">
+                  Save Preferences
+                </Button>
+              </Stack>
+            </Box>
+          )}
         </Container>
       </Paper>
     </Slide>

--- a/client/src/common/components/MainLayout.tsx
+++ b/client/src/common/components/MainLayout.tsx
@@ -23,6 +23,7 @@ import CustomUserButton from './CustomUserButton';
 import useUserRoles from '../hooks/useUserRoles';
 import { ROLES } from '../constants/roles';
 import InvoiceFileUpload from '../../modules/invoices/components/InvoiceFileUpload';
+import CookieBanner from './CookieBanner';
 
 const drawerWidth = 240;
 
@@ -200,6 +201,8 @@ const MainLayout: React.FC = () => {
           </Typography>
         </Container>
       </Box>
+
+      <CookieBanner />
     </Box>
   );
 };

--- a/client/src/common/utils/cookieManager.ts
+++ b/client/src/common/utils/cookieManager.ts
@@ -77,6 +77,42 @@ export const cookieManager = {
     }
   },
 
+  applyPreferences(preferencesParam?: CookiePreferences): void {
+    const preferences = preferencesParam ?? this.getPreferences();
+    if (!preferences) return;
+
+    if (typeof window.gtag !== 'undefined') {
+      window.gtag('consent', 'update', {
+        'analytics_storage': preferences.analytics ? 'granted' : 'denied',
+        'ad_storage': preferences.thirdParty ? 'granted' : 'denied',
+        'functionality_storage': preferences.functional ? 'granted' : 'denied',
+        'personalization_storage': preferences.thirdParty ? 'granted' : 'denied',
+      });
+    }
+
+    if (preferences.consent === 'declined') {
+      this.blockNonEssentialCookies();
+      return;
+    }
+
+    if (!preferences.thirdParty) {
+      this.blockThirdPartyScripts();
+    }
+  },
+
+  saveCategoryPreferences(prefs: { functional: boolean; analytics: boolean; thirdParty: boolean }): void {
+    const preferences: CookiePreferences = {
+      consent: 'accepted',
+      timestamp: new Date().toISOString(),
+      functional: prefs.functional,
+      analytics: prefs.analytics,
+      thirdParty: prefs.thirdParty,
+    };
+
+    localStorage.setItem(COOKIE_CONSENT_KEY, JSON.stringify(preferences));
+    this.applyPreferences(preferences);
+  },
+
   blockThirdPartyScripts(): void {
     const blockedDomains = [
       'google-analytics.com',


### PR DESCRIPTION
Implementation of LEMON-19

add cookies banner

--- Additional Context from User Q&A ---

**Q:** Which surfaces should display the cookie banner? (Client app only, Landing site only, Both client app and landing site)
**A:** Client app only

**Q:** What consent model is required? (Simple Accept/Decline, Accept/Decline with Preferences (functional/analytics/third-party), IAB TCF-compliant granular consent)
**A:** Accept/Decline with Preferences (functional/analytics/third-party)

**Q:** What legal copy and links should be shown? (Provide project-specific Privacy and Cookies Policy URLs, Use placeholder routes (/privacy, /cookies) until content exists, No links (copy only))
**A:** No links

**Q:** What is the default behavior before consent? (Block non-essential cookies/scripts by default until Accept, Allow by default; only block when user Declines, Environment-based toggle)
**A:** Allow by default; only block when user Declines

--- Implementation Plan ---

# Implementation Plan

## Conceptual Checklist

- Confirm reuse of existing CookieBanner and cookieManager.
- Ensure banner supports Accept/Decline and Preferences for functional/analytics/third-party.
- Persist preferences and enforce default: allow by default; block only on Decline.
- Integrate banner at app root to show across all routes.
- Provide a way to reopen preferences (if required) and verify no legal links are shown.

## Overview

Add a cookie banner to the client app only that allows Accept/Decline and category-level Preferences (functional/analytics/third-party). By default, allow all until the user explicitly declines. No legal links should be displayed.

## Assumptions and Rules from CLAUDE.md

- Reuse project patterns: React + MUI, feature-based structure (project CLAUDE.md).
- Keep code lint-clean and TypeScript strict (project CLAUDE.md).
- Use existing shared utilities/components when available (project CLAUDE.md).
- Ambiguity: Manage preferences entry point post-dismissal; propose adding a global "Manage Cookie Preferences" in a shared layout/menu.

## Step-by-Step Implementation

1. Review and adapt CookieBanner
   - Dependencies: MUI
   - Tools/Files: client/src/common/components/CookieBanner.tsx
   - Ensure UI supports Accept, Decline, and Preferences with toggles for functional/analytics/third-party; remove legal links per requirement.

2. Extend preference persistence/enforcement
   - Dependencies: none
   - Tools/Files: client/src/common/utils/cookieManager.ts
   - Add/adjust storage to persist category booleans; maintain default behavior (allow until Decline). Implement selective enforcement for analytics/third-party where applicable.

3. Global integration
   - Dependencies: React Router, layout
   - Tools/Files: client/src/common/components/MainLayout.tsx (or App.tsx)
   - Mount CookieBanner so it renders on all pages; show until user acts (Accept/Decline). Optionally add a global "Manage Cookie Preferences" control.

4. Enforcement behavior
   - Dependencies: none
   - Tools/Files: cookieManager methods
   - On Decline: call blockNonEssentialCookies and blockThirdPartyScripts. On Accept: allowAllCookies. On Preferences: enforce per category (e.g., block analytics/third-party).

5. QA and validation
   - Verify first-load behavior, persistence across reloads, and category toggles. Confirm no legal links. Check accessibility and responsiveness.

## Error Handling and Uncertainties

- localStorage availability: fallbacks already handled; ensure no runtime errors.
- If no analytics/third-party scripts exist yet, category enforcement is a no-op but still persist state.
- Clarify/manage how users reopen preferences post-dismissal; implement a global entry point if approved.