### PR TITLE
1987

### DIFF
--- a/client/src/modules/tenants/tenant-management/TenantManagementPage.tsx
+++ b/client/src/modules/tenants/tenant-management/TenantManagementPage.tsx
@@ -105,8 +105,8 @@ const TenantManagementPage: React.FC<TenantManagementPageProps> = () => {
               variant="contained"
               onClick={openCreateForm}
               sx={{
-                backgroundColor: theme.palette.primary.main,
-                '&:hover': { backgroundColor: theme.palette.primary.dark },
+                backgroundColor: '#E91E63',
+                '&:hover': { backgroundColor: '#C2185B' },
               }}>
               + Add Tenant
             </Button>


### PR DESCRIPTION
Implementation of 1987

Change add tenant button color to pink, thats all, one small chage1 # Implementation Plan ## Conceptual Checklist - Locate the Add Tenant button in TenantManagementPage.tsx - Determine appropriate pink color value (Material UI pink or custom) - Decide on implementation approach (inline style vs theme modification) - Apply color change to button background - Verify the change visually in both light and dark themes - Ensure the change follows Material UI v7 patterns - Run linting to ensure code quality ## Overview Change the "Add Tenant" button background color from the current primary blue (#1976D2) to pink. The button is located in the TenantManagementPage component at lines 104-112. This is a simple styling change requiring modification of the button's `sx` prop. ## Assumptions and Rules from CLAUDE.md **Assumptions:** - Using Material UI default pink color (#e91e63 or '#E91E63') for consistency with MUI palette - Applying to both light and dark themes for consistent UX - Using inline `sx` prop styling (existing pattern in the file) rather than theme modification - The hover state should use a darker pink shade **Relevant Rules:** - From client/CLAUDE.md: "Material UI" + "Emotion" for styling (line 45) - From client/CLAUDE.md: "ESLint runs automatically before starting the dev server" (line 34) - From root CLAUDE.md: "Material UI v7" usage (line 9) - From root CLAUDE.md: "ESLint runs before dev server" - must ensure linting passes (line 190) **No ambiguous or missing rules identified** - the styling approach is clear from existing code patterns. ## Step-by-Step Implementation 1. **Modify the Add Tenant button styling** - Dependencies: None - Tools/Files: Edit tool on `client/src/modules/tenants/tenant-management/TenantManagementPage.tsx` - Action: Replace the current `sx` prop (lines 107-110) with pink color values - Change `backgroundColor: theme.palette.primary.main` to `backgroundColor: '#E91E63'` - Change hover backgroundColor from `theme.palette.primary.dark` to a darker pink like `'#C2185B'` 2. **Verify linting passes** - Dependencies: Step 1 complete - Tools/Files: Bash tool to run `cd client && npm run lint` - Action: Ensure no linting errors introduced ## Error Handling and Uncertainties **Uncertainties:** - Exact pink shade preference not specified - using Material UI standard pink (#E91E63) as it's a safe, accessible choice - Whether to modify both themes - assuming yes for consistency **Mitigation:** - The chosen pink (#E91E63) is Material UI's default pink.main, ensuring good contrast and accessibility - If different shade needed, it's a simple one-value change - No breaking changes expected as this is purely cosmetic