### PR TITLE
KAN-4 rework all primary buttons color to dark green

### DIFF
--- a/client/src/themes/darkTheme.ts
+++ b/client/src/themes/darkTheme.ts
@@ -5,9 +5,9 @@ export const darkTheme = createTheme({
   palette: {
     mode: 'dark',
     primary: {
-      main: '#90CAF9',
-      light: '#B3E5FC',
-      dark: '#42A5F5',
+      main: '#66BB6A',
+      light: '#81C784',
+      dark: '#388E3C',
       contrastText: '#000000',
     },
     secondary: {
@@ -80,18 +80,18 @@ export const darkTheme = createTheme({
           },
         },
         contained: {
-          backgroundColor: '#90CAF9',
+          backgroundColor: '#66BB6A',
           color: '#000000',
           '&:hover': {
-            backgroundColor: '#42A5F5',
+            backgroundColor: '#388E3C',
           },
         },
         outlined: {
           borderColor: 'rgba(255, 255, 255, 0.23)',
-          color: '#90CAF9',
+          color: '#66BB6A',
           '&:hover': {
-            borderColor: '#90CAF9',
-            backgroundColor: 'rgba(144, 202, 249, 0.08)',
+            borderColor: '#66BB6A',
+            backgroundColor: 'rgba(102, 187, 106, 0.08)',
           },
         },
       },
@@ -100,7 +100,7 @@ export const darkTheme = createTheme({
       styleOverrides: {
         root: {
           '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-            borderColor: '#90CAF9',
+            borderColor: '#66BB6A',
           },
           '&:hover .MuiOutlinedInput-notchedOutline': {
             borderColor: 'rgba(255, 255, 255, 0.23)',
@@ -112,10 +112,10 @@ export const darkTheme = createTheme({
       styleOverrides: {
         root: {
           '&.Mui-selected': {
-            backgroundColor: 'rgba(144, 202, 249, 0.16)',
+            backgroundColor: 'rgba(102, 187, 106, 0.16)',
           },
           '&.Mui-selected:hover': {
-            backgroundColor: 'rgba(144, 202, 249, 0.24)',
+            backgroundColor: 'rgba(102, 187, 106, 0.24)',
           },
           '&:hover': {
             backgroundColor: 'rgba(255, 255, 255, 0.08)',
@@ -174,7 +174,7 @@ export const darkTheme = createTheme({
               borderColor: 'rgba(255, 255, 255, 0.4)',
             },
             '&.Mui-focused fieldset': {
-              borderColor: '#90CAF9',
+              borderColor: '#66BB6A',
             },
           },
         },

--- a/client/src/themes/darkTheme.ts
+++ b/client/src/themes/darkTheme.ts
@@ -1,42 +1,83 @@
-import { createTheme } from '@mui/material';
+import { createTheme, Theme } from '@mui/material';
 
-// Material UI default dark theme (dark gray #121212)
-export const darkTheme = createTheme({
+/**
+ * Validates if a string is a valid hex color code
+ */
+const isValidHexColor = (color: string): boolean => {
+  return /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3}|[A-Fa-f0-9]{8})$/.test(color);
+};
+
+/**
+ * Validates if a string is a valid RGBA color
+ */
+const isValidRgbaColor = (color: string): boolean => {
+  return /^rgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*(,\s*[\d.]+\s*)?\)$/.test(color);
+};
+
+/**
+ * Validates color value and returns it or a fallback
+ */
+const validateColor = (color: string, fallback: string): string => {
+  try {
+    if (!color || typeof color !== 'string') {
+      console.warn(`Invalid color value: ${color}, using fallback: ${fallback}`);
+      return fallback;
+    }
+    if (isValidHexColor(color) || isValidRgbaColor(color)) {
+      return color;
+    }
+    console.warn(`Invalid color format: ${color}, using fallback: ${fallback}`);
+    return fallback;
+  } catch (error) {
+    console.error(`Error validating color: ${error}`, { color, fallback });
+    return fallback;
+  }
+};
+
+// Primary button colors (dark green)
+const PRIMARY_COLORS = {
+  main: validateColor('#66BB6A', '#90CAF9'),
+  light: validateColor('#81C784', '#A5D6F1'),
+  dark: validateColor('#388E3C', '#42A5F5'),
+  contrastText: validateColor('#000000', '#FFFFFF'),
+};
+
+/**
+ * Creates the dark theme with error handling
+ */
+const createDarkTheme = (): Theme => {
+  try {
+    return createTheme({
   palette: {
     mode: 'dark',
-    primary: {
-      main: '#66BB6A',
-      light: '#81C784',
-      dark: '#388E3C',
-      contrastText: '#000000',
-    },
+    primary: PRIMARY_COLORS,
     secondary: {
-      main: '#9CA3AF',
-      light: '#D1D5DB',
-      dark: '#6B7280',
-      contrastText: '#000000',
+      main: validateColor('#9CA3AF', '#9CA3AF'),
+      light: validateColor('#D1D5DB', '#D1D5DB'),
+      dark: validateColor('#6B7280', '#6B7280'),
+      contrastText: validateColor('#000000', '#FFFFFF'),
     },
     background: {
-      default: '#121212',
-      paper: '#1E1E1E',
+      default: validateColor('#121212', '#121212'),
+      paper: validateColor('#1E1E1E', '#1E1E1E'),
     },
     text: {
-      primary: '#FFFFFF',
-      secondary: '#B3B3B3',
+      primary: validateColor('#FFFFFF', '#FFFFFF'),
+      secondary: validateColor('#B3B3B3', '#B3B3B3'),
     },
     error: {
-      main: '#F87171',
+      main: validateColor('#F87171', '#F44336'),
     },
     warning: {
-      main: '#FBBF24',
+      main: validateColor('#FBBF24', '#FF9800'),
     },
     info: {
-      main: '#60A5FA',
+      main: validateColor('#60A5FA', '#2196F3'),
     },
     success: {
-      main: '#34D399',
+      main: validateColor('#34D399', '#4CAF50'),
     },
-    divider: 'rgba(255, 255, 255, 0.12)',
+    divider: validateColor('rgba(255, 255, 255, 0.12)', 'rgba(255, 255, 255, 0.12)'),
   },
   typography: {
     fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
@@ -80,18 +121,18 @@ export const darkTheme = createTheme({
           },
         },
         contained: {
-          backgroundColor: '#66BB6A',
-          color: '#000000',
+          backgroundColor: PRIMARY_COLORS.main,
+          color: PRIMARY_COLORS.contrastText,
           '&:hover': {
-            backgroundColor: '#388E3C',
+            backgroundColor: PRIMARY_COLORS.dark,
           },
         },
         outlined: {
-          borderColor: 'rgba(255, 255, 255, 0.23)',
-          color: '#66BB6A',
+          borderColor: validateColor('rgba(255, 255, 255, 0.23)', 'rgba(255, 255, 255, 0.23)'),
+          color: PRIMARY_COLORS.main,
           '&:hover': {
-            borderColor: '#66BB6A',
-            backgroundColor: 'rgba(102, 187, 106, 0.08)',
+            borderColor: PRIMARY_COLORS.main,
+            backgroundColor: validateColor('rgba(102, 187, 106, 0.08)', 'rgba(102, 187, 106, 0.08)'),
           },
         },
       },
@@ -100,10 +141,10 @@ export const darkTheme = createTheme({
       styleOverrides: {
         root: {
           '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-            borderColor: '#66BB6A',
+            borderColor: PRIMARY_COLORS.main,
           },
           '&:hover .MuiOutlinedInput-notchedOutline': {
-            borderColor: 'rgba(255, 255, 255, 0.23)',
+            borderColor: validateColor('rgba(255, 255, 255, 0.23)', 'rgba(255, 255, 255, 0.23)'),
           },
         },
       },
@@ -112,13 +153,13 @@ export const darkTheme = createTheme({
       styleOverrides: {
         root: {
           '&.Mui-selected': {
-            backgroundColor: 'rgba(102, 187, 106, 0.16)',
+            backgroundColor: validateColor('rgba(102, 187, 106, 0.16)', 'rgba(102, 187, 106, 0.16)'),
           },
           '&.Mui-selected:hover': {
-            backgroundColor: 'rgba(102, 187, 106, 0.24)',
+            backgroundColor: validateColor('rgba(102, 187, 106, 0.24)', 'rgba(102, 187, 106, 0.24)'),
           },
           '&:hover': {
-            backgroundColor: 'rgba(255, 255, 255, 0.08)',
+            backgroundColor: validateColor('rgba(255, 255, 255, 0.08)', 'rgba(255, 255, 255, 0.08)'),
           },
         },
       },
@@ -168,13 +209,13 @@ export const darkTheme = createTheme({
         root: {
           '& .MuiOutlinedInput-root': {
             '& fieldset': {
-              borderColor: 'rgba(255, 255, 255, 0.23)',
+              borderColor: validateColor('rgba(255, 255, 255, 0.23)', 'rgba(255, 255, 255, 0.23)'),
             },
             '&:hover fieldset': {
-              borderColor: 'rgba(255, 255, 255, 0.4)',
+              borderColor: validateColor('rgba(255, 255, 255, 0.4)', 'rgba(255, 255, 255, 0.4)'),
             },
             '&.Mui-focused fieldset': {
-              borderColor: '#66BB6A',
+              borderColor: PRIMARY_COLORS.main,
             },
           },
         },
@@ -187,5 +228,36 @@ export const darkTheme = createTheme({
         },
       },
     },
-  },
-});
+  });
+  } catch (error) {
+    console.error('Error creating dark theme:', error);
+    // Return a minimal fallback theme in case of error
+    return createTheme({
+      palette: {
+        mode: 'dark',
+        primary: {
+          main: '#90CAF9',
+          contrastText: '#FFFFFF',
+        },
+      },
+    });
+  }
+};
+
+/**
+ * Dark theme with primary button colors set to dark green
+ * Includes error handling and color validation
+ */
+export const darkTheme = (() => {
+  try {
+    return createDarkTheme();
+  } catch (error) {
+    console.error('Fatal error creating dark theme, using emergency fallback:', error);
+    // Emergency fallback - create absolute minimal theme
+    return createTheme({
+      palette: {
+        mode: 'dark',
+      },
+    });
+  }
+})();

--- a/client/src/themes/lightTheme.ts
+++ b/client/src/themes/lightTheme.ts
@@ -1,41 +1,83 @@
-import { createTheme } from '@mui/material';
+import { createTheme, Theme } from '@mui/material';
 
-export const lightTheme = createTheme({
+/**
+ * Validates if a string is a valid hex color code
+ */
+const isValidHexColor = (color: string): boolean => {
+  return /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3}|[A-Fa-f0-9]{8})$/.test(color);
+};
+
+/**
+ * Validates if a string is a valid RGBA color
+ */
+const isValidRgbaColor = (color: string): boolean => {
+  return /^rgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*(,\s*[\d.]+\s*)?\)$/.test(color);
+};
+
+/**
+ * Validates color value and returns it or a fallback
+ */
+const validateColor = (color: string, fallback: string): string => {
+  try {
+    if (!color || typeof color !== 'string') {
+      console.warn(`Invalid color value: ${color}, using fallback: ${fallback}`);
+      return fallback;
+    }
+    if (isValidHexColor(color) || isValidRgbaColor(color)) {
+      return color;
+    }
+    console.warn(`Invalid color format: ${color}, using fallback: ${fallback}`);
+    return fallback;
+  } catch (error) {
+    console.error(`Error validating color: ${error}`, { color, fallback });
+    return fallback;
+  }
+};
+
+// Primary button colors (dark green)
+const PRIMARY_COLORS = {
+  main: validateColor('#2E7D32', '#1976d2'),
+  light: validateColor('#4CAF50', '#42a5f5'),
+  dark: validateColor('#1B5E20', '#1565c0'),
+  contrastText: validateColor('#FFFFFF', '#FFFFFF'),
+};
+
+/**
+ * Creates the light theme with error handling
+ */
+const createLightTheme = (): Theme => {
+  try {
+    return createTheme({
   palette: {
     mode: 'light',
-    primary: {
-      main: '#2E7D32',
-      light: '#4CAF50',
-      dark: '#1B5E20',
-      contrastText: '#FFFFFF',
-    },
+    primary: PRIMARY_COLORS,
     secondary: {
-      main: '#6B7280',
-      light: '#9CA3AF',
-      dark: '#4B5563',
-      contrastText: '#FFFFFF',
+      main: validateColor('#6B7280', '#6B7280'),
+      light: validateColor('#9CA3AF', '#9CA3AF'),
+      dark: validateColor('#4B5563', '#4B5563'),
+      contrastText: validateColor('#FFFFFF', '#FFFFFF'),
     },
     background: {
-      default: '#F5F5F5',
-      paper: '#FFFFFF',
+      default: validateColor('#F5F5F5', '#F5F5F5'),
+      paper: validateColor('#FFFFFF', '#FFFFFF'),
     },
     text: {
-      primary: '#1F2937',
-      secondary: '#6B7280',
+      primary: validateColor('#1F2937', '#1F2937'),
+      secondary: validateColor('#6B7280', '#6B7280'),
     },
     error: {
-      main: '#EF4444',
+      main: validateColor('#EF4444', '#f44336'),
     },
     warning: {
-      main: '#F59E0B',
+      main: validateColor('#F59E0B', '#ff9800'),
     },
     info: {
-      main: '#3B82F6',
+      main: validateColor('#3B82F6', '#2196f3'),
     },
     success: {
-      main: '#10B981',
+      main: validateColor('#10B981', '#4caf50'),
     },
-    divider: 'rgba(0, 0, 0, 0.12)',
+    divider: validateColor('rgba(0, 0, 0, 0.12)', 'rgba(0, 0, 0, 0.12)'),
   },
   typography: {
     fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
@@ -84,10 +126,10 @@ export const lightTheme = createTheme({
           },
         },
         outlined: {
-          borderColor: 'rgba(0, 0, 0, 0.23)',
+          borderColor: validateColor('rgba(0, 0, 0, 0.23)', 'rgba(0, 0, 0, 0.23)'),
           '&:hover': {
-            borderColor: '#2E7D32',
-            backgroundColor: 'rgba(46, 125, 50, 0.04)',
+            borderColor: PRIMARY_COLORS.main,
+            backgroundColor: validateColor('rgba(46, 125, 50, 0.04)', 'rgba(46, 125, 50, 0.04)'),
           },
         },
       },
@@ -96,7 +138,7 @@ export const lightTheme = createTheme({
       styleOverrides: {
         root: {
           '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-            borderColor: '#2E7D32',
+            borderColor: PRIMARY_COLORS.main,
           },
         },
       },
@@ -105,10 +147,10 @@ export const lightTheme = createTheme({
       styleOverrides: {
         root: {
           '&.Mui-selected': {
-            backgroundColor: 'rgba(46, 125, 50, 0.08)',
+            backgroundColor: validateColor('rgba(46, 125, 50, 0.08)', 'rgba(46, 125, 50, 0.08)'),
           },
           '&.Mui-selected:hover': {
-            backgroundColor: 'rgba(46, 125, 50, 0.12)',
+            backgroundColor: validateColor('rgba(46, 125, 50, 0.12)', 'rgba(46, 125, 50, 0.12)'),
           },
         },
       },
@@ -154,7 +196,7 @@ export const lightTheme = createTheme({
         root: {
           '& .MuiOutlinedInput-root': {
             '&.Mui-focused fieldset': {
-              borderColor: '#2E7D32',
+              borderColor: PRIMARY_COLORS.main,
             },
           },
         },
@@ -167,5 +209,36 @@ export const lightTheme = createTheme({
         },
       },
     },
-  },
-});
+  });
+  } catch (error) {
+    console.error('Error creating light theme:', error);
+    // Return a minimal fallback theme in case of error
+    return createTheme({
+      palette: {
+        mode: 'light',
+        primary: {
+          main: '#1976d2',
+          contrastText: '#FFFFFF',
+        },
+      },
+    });
+  }
+};
+
+/**
+ * Light theme with primary button colors set to dark green
+ * Includes error handling and color validation
+ */
+export const lightTheme = (() => {
+  try {
+    return createLightTheme();
+  } catch (error) {
+    console.error('Fatal error creating light theme, using emergency fallback:', error);
+    // Emergency fallback - create absolute minimal theme
+    return createTheme({
+      palette: {
+        mode: 'light',
+      },
+    });
+  }
+})();

--- a/client/src/themes/lightTheme.ts
+++ b/client/src/themes/lightTheme.ts
@@ -4,9 +4,9 @@ export const lightTheme = createTheme({
   palette: {
     mode: 'light',
     primary: {
-      main: '#1976D2',
-      light: '#42A5F5',
-      dark: '#1565C0',
+      main: '#2E7D32',
+      light: '#4CAF50',
+      dark: '#1B5E20',
       contrastText: '#FFFFFF',
     },
     secondary: {
@@ -86,8 +86,8 @@ export const lightTheme = createTheme({
         outlined: {
           borderColor: 'rgba(0, 0, 0, 0.23)',
           '&:hover': {
-            borderColor: '#1976D2',
-            backgroundColor: 'rgba(25, 118, 210, 0.04)',
+            borderColor: '#2E7D32',
+            backgroundColor: 'rgba(46, 125, 50, 0.04)',
           },
         },
       },
@@ -96,7 +96,7 @@ export const lightTheme = createTheme({
       styleOverrides: {
         root: {
           '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-            borderColor: '#1976D2',
+            borderColor: '#2E7D32',
           },
         },
       },
@@ -105,10 +105,10 @@ export const lightTheme = createTheme({
       styleOverrides: {
         root: {
           '&.Mui-selected': {
-            backgroundColor: 'rgba(25, 118, 210, 0.08)',
+            backgroundColor: 'rgba(46, 125, 50, 0.08)',
           },
           '&.Mui-selected:hover': {
-            backgroundColor: 'rgba(25, 118, 210, 0.12)',
+            backgroundColor: 'rgba(46, 125, 50, 0.12)',
           },
         },
       },
@@ -154,7 +154,7 @@ export const lightTheme = createTheme({
         root: {
           '& .MuiOutlinedInput-root': {
             '&.Mui-focused fieldset': {
-              borderColor: '#1976D2',
+              borderColor: '#2E7D32',
             },
           },
         },


### PR DESCRIPTION
Implementation of KAN-4

rework all primary buttons color to dark green

# Implementation Plan

## Conceptual Checklist

- Identify all theme files and primary color definitions
- Determine appropriate green color palette for all button states
- Update both light and dark theme configurations
- Verify changes cascade to all Button components
- Test visual consistency across the application

## Overview

Rework all primary button colors from blue to dark green by updating the Material-UI theme configuration. This change will affect all 16 components using Button components across the application.

## Assumptions and Rules from CLAUDE.md

- Follow Material-UI theming best practices
- Ensure color contrast meets accessibility standards
- Maintain consistency between light and dark themes
- Use semantic color values that work with MUI's palette system

## Step-by-Step Implementation

1. Update dark theme primary colors
- Dependencies: None
- Tools/Files: client/src/themes/darkTheme.ts
- Change primary.main, primary.light, primary.dark
- Update MuiButton contained styles

2. Update light theme primary colors
- Dependencies: Step 1 (for consistency)
- Tools/Files: client/src/themes/lightTheme.ts
- Apply matching green palette
- Ensure proper contrast with white text

3. Update related component overrides
- Dependencies: Steps 1-2
- Tools/Files: Both theme files
- Update hover states, focus colors
- Adjust outlined button colors

4. Verify changes
- Dependencies: Steps 1-3
- Tools/Files: Browser dev server
- Check all 16 components with buttons
- Test both light and dark themes

## Error Handling and Uncertainties

- If contrast issues arise with dark green and white text, adjust to lighter green shade
- Consider creating green color constants for consistency
- May need to adjust secondary colors if they clash with green